### PR TITLE
Analysis of market value of renewables and storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,15 @@
 __pycache__
 
 creds.json
+data/ninja/ninja_pv_europe_v1.1_merra2.csv
+data/ninja/ninja_pv_europe_v1.1_sarah.csv
+data/ninja/Ninja-PV-Readme-v1.1.pdf
+data/ninja/Meta Data for Wind Farms.xlsx
+data/ninja/Ninja-Wind-Readme-v1.1.pdf
+data/ninja/ninja_wind_europe_v1.1_current_national.csv
+data/ninja/ninja_wind_europe_v1.1_current_on-offshore.csv
+data/ninja/ninja_wind_europe_v1.1_future_longterm_national.csv
+data/ninja/ninja_wind_europe_v1.1_future_nearterm_national.csv
+data/ninja/ninja_wind_europe_v1.1_future_nearterm_on-offshore.csv
+data/ninja/pv.zip
+data/ninja/wind.zip

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,14 @@ data/ninja/ninja_wind_europe_v1.1_future_nearterm_national.csv
 data/ninja/ninja_wind_europe_v1.1_future_nearterm_on-offshore.csv
 data/ninja/pv.zip
 data/ninja/wind.zip
+data/ninja/pv-gis-38-east.csv
+data/ninja/pv-gis-38-west.csv
+data/ninja/pv-gis-opt-east.csv
+data/ninja/pv-gis-opt-opt.csv
+data/ninja/pv-gis-opt-west.csv
+data/ninja/pv-gis-opt.csv
+data/ninja/pv-gis-two-axis.csv
+data/ninja/pv-gis-vertical-east.csv
+data/ninja/pv-gis-vertical-north.csv
+data/ninja/pv-gis-vertical-south.csv
+data/ninja/pv-gis-vertical-west.csv

--- a/_shared.r
+++ b/_shared.r
@@ -39,7 +39,7 @@ rm(creds)
 
 # - HELPERS --------------------------------------------------------------------
 removeLastDays = function(d, days = 1) {
-    d[date <= max(date) - days, ]
+    d[date <= max(date, na.rm = TRUE) - days, ]
 }
 
 # logging

--- a/analysis/value-renewables.R
+++ b/analysis/value-renewables.R
@@ -4,84 +4,142 @@ rm(list = ls())
 source("_shared.r")
 source("calc/prediction-gas-consumption/_functions.r")
 
+download_ninja = FALSE
+
+
+
+if(download_ninja){
+    PV_FILE <- "data/ninja/pv.zip"
+    WIND_FILE <- "data/ninja/wind.zip"
+    EX_DIR <- "data/ninja/"
+    download.file("https://renewables.ninja/downloads/ninja_europe_pv_v1.1.zip",
+              PV_FILE)
+    download.file("https://renewables.ninja/downloads/ninja_europe_wind_v1.1.zip",
+              WIND_FILE)
+    unzip(PV_FILE, exdir = EX_DIR)
+    unzip(WIND_FILE, exdir = EX_DIR)
+}
+
+COUNTRIES <- c("AT", "ES", "DE", "FR")
+
 d.generation = loadFromStorage(id = "electricity-generation-hourly")
+
 d.prices = loadFromStorage(id = "electricity-price-entsoe-hourly") %>%
     mutate(country = substr(AreaName, 1,2))
 
-d.cap.fact <- d.generation %>%
-    filter(country %in% c("AT", "ES")) %>%
+d.gen.sel <- d.generation %>%
+    filter(country %in% COUNTRIES) %>%
     group_by(year = year(DateTime), source, country) %>%
-    mutate(cap_fact = value / max(value)) %>%
     mutate(hour_of_year = 1:n()) %>%
     ungroup()
-
-d.cap.fact %>%
-    filter(source %in% c("Solar", "Wind Onshore")) %>%
-    filter(year > 2014) %>%
-    ggplot(aes(x = DateTime, y = cap_fact)) +
-    geom_smooth(aes(col = source)) +
-    facet_wrap(. ~ country)
 
 d.prices.filtered <- d.prices %>%
     mutate(year = year(DateTime)) %>%
     filter(ResolutionCode == "PT60M") %>%
     filter(year > 2018) %>%
-    filter(AreaName %in% c("AT BZN", "ES BZN")) %>%
-    arrange(DateTime)
+    filter(country %in% COUNTRIES) %>%
+    arrange(DateTime) %>%
+    dplyr::select(DateTime, year, mean, country)
 
-full_join(d.cap.fact,
-          d.prices.filtered,
-          by = c("DateTime" = "DateTime", "country" = "country")) %>%
-    filter(source %in% c("Solar", "Wind Onshore")) %>%
-    mutate(value = cap_fact * mean) %>%
-    mutate(month = month(DateTime)) %>%
-    mutate(year = year(DateTime)) %>%
-    filter(year > 2018) %>%
-    dplyr::select(year, month, DateTime, source, value, country) %>%
-    filter(! (source %in% c("Fossil Hard coal",
-                            "Other",
-                            "Other renewable",
-                            "Fossil Oil"))) %>%
-    filter(!is.na(source)) %>%
-    group_by(year, month, country, source) %>%
-    summarize(value = sum(value, na.rm = TRUE),
-              DateTime = min(DateTime)) %>%
+d.prices.filtered %>%
+    mutate(hour = hour(DateTime)) %>%
+    group_by(year, country) %>%
+    mutate(n = 1:n()) %>%
     ungroup() %>%
-    group_by(country, source) %>%
-    mutate(rollvalue = rollsum(value, 12, fill = NA, align = "right") / 1000) %>%
+    group_by(year, hour, country) %>%
+    mutate(mean = mean(mean)) %>%
+    ungroup %>%
+    group_by(year, country) %>%
+    mutate(mean = mean / mean(mean)) %>%
     ungroup() %>%
-    #na.omit() %>%
-    ggplot(aes(x = DateTime, y = rollvalue)) +
-    geom_line(aes(col = source)) +
+    ggplot(aes(x = hour, y = mean)) +
+    geom_line(aes(col = as.character(year))) +
     facet_wrap(.~country)
 
-full_join(d.cap.fact,
+### VALUE ###
+full_join(d.gen.sel,
           d.prices.filtered,
           by = c("DateTime" = "DateTime",
                  "country" = "country")) %>%
-    filter(! (source %in% c("Fossil Hard coal",
-                            "Other",
-                            "Other renewable",
-                            "Fossil Oil",
-                            "Geothermal",
-                            "Waste",
-                            "Biomass"))) %>%
     filter(source %in% c("Solar", "Wind Onshore", "Fossil Gas")) %>%
     filter(!is.na(source)) %>%
     mutate(value.power = value * mean) %>%
     mutate(month = month(DateTime)) %>%
     mutate(year = year(DateTime)) %>%
-    filter(year > 2018) %>%
-
-#    dplyr::select(year, month, DateTime, source, value) %>%
+    filter(year > 2022) %>%
     group_by(year, month, country, source) %>%
     summarize(value = sum(value.power, na.rm = TRUE) / sum(value, na.rm = TRUE),
               DateTime = min(DateTime)) %>%
     ungroup() %>%
+    mutate(Technology = source) %>%
     ggplot(aes(x = DateTime, y = value)) +
-    geom_line(aes(col = source)) +
+    geom_line(aes(col = Technology)) +
+    facet_wrap(.~country) +
+    xlab("Date") +
+    ylab("Value of Electricity (€/MWh)")
+
+### CAP FACT ###
+ninja_pv <- read_csv("data/ninja/ninja_pv_europe_v1.1_sarah.csv") %>%
+    gather(country, value, -time) %>%
+    filter(country %in% COUNTRIES) %>%
+    group_by(year(time), country) %>%
+    mutate(t = 1:n()) %>%
+    ungroup() %>%
+    group_by(country, t) %>%
+    summarize(pv = mean(value))
+
+ninja_pv %>%
+    ggplot(aes(x = t, y = pv)) +
+    geom_line(aes(col = country)) +
     facet_wrap(.~country)
-    #geom_smooth(aes(col = source))
-    #facet_wrap(. ~ source) +
-    #ylim(c(0, 100))
+
+ninja_wind <- read_csv("data/ninja/ninja_wind_europe_v1.1_future_nearterm_national.csv") %>%
+    gather(country, value, -time) %>%
+    filter(country %in% COUNTRIES) %>%
+    group_by(year(time), country) %>%
+    mutate(t = 1:n()) %>%
+    ungroup() %>%
+    group_by(country, t) %>%
+    summarize(wind = mean(value))
+
+ninja_wind %>%
+    ggplot(aes(x = t, y = wind)) +
+    geom_line(aes(col = country))
+
+
+d.prices.filtered <- d.prices.filtered %>%
+    group_by(year, country) %>%
+    mutate(t = 1:n()) %>%
+    ungroup()
+
+
+max_date <- max(d.prices.filtered$DateTime)
+
+full_join(d.prices.filtered,
+          ninja_pv,
+          by = c("t" = "t", "country" = "country")) %>%
+    full_join(ninja_wind,
+              by = c("t" = "t", "country" = "country")) %>%
+    gather(source, cap_fact, -DateTime, -year, -mean, -country, -t) %>%
+    mutate(value = cap_fact * mean) %>%
+    mutate(month = month(DateTime)) %>%
+    mutate(year = year(DateTime)) %>%
+    filter(year > 2018) %>%
+    dplyr::select(year, month, DateTime, source, value, country) %>%
+    group_by(year, month, country, source) %>%
+    summarize(value = sum(value, na.rm = TRUE),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    group_by(country, source) %>%
+    #mutate(rollvalue = rollsum(value, 12, fill = NA, align = "right") / 1000) %>%
+    mutate(rollvalue = value / 1000) %>%
+    ungroup() %>%
+    #na.omit() %>%
+    filter(year < max(year) | (year == max(year) & month < month(max_date))) %>%
+    ggplot(aes(x = DateTime, y = rollvalue)) +
+    geom_line(aes(col = source)) +
+    geom_smooth(aes(col = source), method = "gam") +
+    facet_wrap(.~country)
+
+
 

--- a/analysis/value-renewables.R
+++ b/analysis/value-renewables.R
@@ -5,7 +5,7 @@ source("_shared.r")
 source("calc/prediction-gas-consumption/_functions.r")
 
 download_ninja = FALSE
-
+download_pv_gis = FALSE
 
 
 if(download_ninja){
@@ -18,6 +18,40 @@ if(download_ninja){
               WIND_FILE)
     unzip(PV_FILE, exdir = EX_DIR)
     unzip(WIND_FILE, exdir = EX_DIR)
+}
+
+if(download_pv_gis){
+
+    PV_GIS_OPT = "data/ninja/pv-gis-opt-opt.csv"
+    PV_GIS_EAST = "data/ninja/pv-gis-38-east.csv"
+    PV_GIS_WEST = "data/ninja/pv-gis-38-west.csv"
+    PV_GIS_VERTICAL_EAST = "data/ninja/pv-gis-vertical-east.csv"
+    PV_GIS_VERTICAL_WEST = "data/ninja/pv-gis-vertical-west.csv"
+    PV_GIS_VERTICAL_NORTH = "data/ninja/pv-gis-vertical-north.csv"
+    PV_GIS_VERTICAL_SOUTH = "data/ninja/pv-gis-vertical-south.csv"
+    PV_GIS_TWO_AXIS = "data/ninja/pv-gis-two-axis.csv"
+
+
+    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&optimalangles=1",
+                  PV_GIS_OPT)
+    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=38&aspect=-90",
+                  PV_GIS_EAST)
+    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=38&aspect=90",
+                  PV_GIS_WEST)
+    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=-90",
+                  PV_GIS_VERTICAL_EAST)
+    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=90",
+                  PV_GIS_VERTICAL_WEST)
+
+    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=0",
+                  PV_GIS_VERTICAL_SOUTH)
+
+    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=180",
+                  PV_GIS_VERTICAL_NORTH)
+
+    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&trackingtype=2",
+                  PV_GIS_TWO_AXIS)
+
 }
 
 COUNTRIES <- c("AT", "ES", "DE", "FR")
@@ -61,12 +95,12 @@ full_join(d.gen.sel,
           d.prices.filtered,
           by = c("DateTime" = "DateTime",
                  "country" = "country")) %>%
-    filter(source %in% c("Solar", "Wind Onshore", "Fossil Gas")) %>%
+    filter(source %in% c("Solar", "Wind Onshore", "Fossil Gas", "Nuclear")) %>%
     filter(!is.na(source)) %>%
     mutate(value.power = value * mean) %>%
     mutate(month = month(DateTime)) %>%
     mutate(year = year(DateTime)) %>%
-    filter(year > 2022) %>%
+    filter(year > 2018) %>%
     group_by(year, month, country, source) %>%
     summarize(value = sum(value.power, na.rm = TRUE) / sum(value, na.rm = TRUE),
               DateTime = min(DateTime)) %>%
@@ -140,6 +174,134 @@ full_join(d.prices.filtered,
     geom_line(aes(col = source)) +
     geom_smooth(aes(col = source), method = "gam") +
     facet_wrap(.~country)
+
+
+
+
+
+
+
+########## different system values for austria
+list.csv.files <- c(PV_GIS_OPT,
+                    PV_GIS_EAST,
+                    PV_GIS_WEST,
+                    PV_GIS_VERTICAL_EAST,
+                    PV_GIS_VERTICAL_WEST,
+                    PV_GIS_VERTICAL_NORTH,
+                    PV_GIS_VERTICAL_SOUTH,
+                    PV_GIS_TWO_AXIS)
+
+d.pv.gis <- read_csv(list_csv_files, skip=19, id="type") %>%
+    mutate(time=ymd_hm(time)) %>%
+    mutate(type = str_remove(type, "pv-gis")) %>%
+    mutate(type = str_remove(type, "\\.csv")) %>%
+    mutate(type = str_remove(type, "data")) %>%
+    mutate(type = str_remove(type, "ninja")) %>%
+    mutate(type = str_remove_all(type, "\\\\")) %>%
+    na.omit()
+
+
+
+### test on pv_gis
+d.pv.gis %>%
+    group_by(year = year(time), month=month(time)) %>%
+    summarize(P=mean(P)) %>%
+    ggplot(aes(x=year, y=P)) +
+    geom_bar(stat="identity") +
+    facet_wrap(.~month)
+
+d.pv.gis %>%
+    filter(year(time) == 2018) %>%
+    group_by(month=month(time),time=hour(time), type) %>%
+    summarize(P=mean(P)) %>%
+    ggplot(aes(x=time, y=P)) +
+    geom_line(aes(col=type)) +
+    facet_wrap(.~month)
+
+d.pv.gis.2018 = d.pv.gis %>%
+    filter(year(time) == 2018) %>%
+    dplyr::select(time, type, P) %>%
+    spread(type, P) %>%
+    mutate(vertical.north.south = 0.5 * `//-vertical-north` + 0.5 * `//-vertical-south`) %>%
+    mutate(vertical.east.west = 0.5 * `//-vertical-east` + 0.5 * `//-vertical-west`) %>%
+    mutate(angle.east.west = 0.5 * `//-38-east` + 0.5 * `//-38-west`) %>%
+    dplyr::select(time,
+                  vertical.north.south,
+                  vertical.east.west,
+                  angle.east.west,
+                  opt.opt=`//-opt-opt`,
+                  two.axis=`//-two-axis`) %>%
+    gather(type, P, -time) %>%
+    group_by(type) %>%
+    mutate(t=1:n()) %>%
+    ungroup()
+
+
+d.pv.gis.2018 %>%
+    group_by(month=month(time),time=hour(time), type) %>%
+    summarize(P=mean(P)) %>%
+    ggplot(aes(x=time, y=P)) +
+    geom_line(aes(col=type)) +
+    facet_wrap(.~month)
+
+
+
+d.join.prices.pv <- full_join(d.prices.filtered %>%
+              filter(country == "AT"),
+          d.pv.gis.2018,
+          by = c("t" = "t"),
+          relationship = "many-to-many") %>%
+    mutate(value = P / 1000 * mean) %>%
+    mutate(month = month(DateTime)) %>%
+    mutate(year = year(DateTime)) %>%
+    filter(year > 2018) %>%
+    dplyr::select(year, month, DateTime, type, value, country) %>%
+    group_by(year, month, country, type) %>%
+    summarize(value = sum(value, na.rm = TRUE),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    group_by(country, type) %>%
+    #mutate(rollvalue = rollsum(value, 12, fill = NA, align = "right") / 1000) %>%
+    mutate(rollvalue = value / 1000) %>%
+    ungroup() %>%
+    #na.omit() %>%
+    filter(year < max(year) | (year == max(year) & month < month(max_date)))
+
+d.join.prices.pv %>%
+    filter(year > 2022) %>%
+    ggplot(aes(x = DateTime, y = rollvalue)) +
+    geom_line(aes(col = type)) +
+    #geom_smooth(aes(col = type), method = "gam")
+    ylab("Income for 1kw_peak (€/Month)")
+
+d.join.prices.pv %>%
+    group_by(year, type) %>%
+    mutate(c_value=cumsum(rollvalue)) %>%
+    ungroup() %>%
+    ggplot(aes(x = month(DateTime), y = c_value)) +
+    geom_line(aes(col = type)) +
+    facet_wrap(.~year) +
+    theme_bw() +
+    xlab("Month") +
+    ylab("Cumulative income (€/kw_peak)")
+
+d.join.prices.pv %>%
+    group_by(type) %>%
+    mutate(c_value=cumsum(rollvalue)) %>%
+    ungroup() %>%
+    ggplot(aes(x = DateTime, y = c_value)) +
+    geom_line(aes(col = type)) +
+    theme_bw() +
+    xlab("Month") +
+    ylab("Cumulative income (€/kw_peak)")
+
+
+
+
+
+
+
+
 
 
 

--- a/analysis/value-renewables.R
+++ b/analysis/value-renewables.R
@@ -4,8 +4,8 @@ rm(list = ls())
 source("_shared.r")
 source("calc/prediction-gas-consumption/_functions.r")
 
-download_ninja = FALSE
-download_pv_gis = FALSE
+download_ninja = TRUE
+download_pv_gis = TRUE
 
 
 if(download_ninja){
@@ -177,8 +177,22 @@ full_join(d.prices.filtered,
 
 
 
-
-
+d.prices.filtered %>%
+    mutate(day = yday(DateTime)) %>%
+    mutate(month = month(DateTime)) %>%
+    group_by(year, month, day, country) %>%
+    summarize(spread = max(mean) - min(mean),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    group_by(year, month, country) %>%
+    summarize(spread = mean(spread),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    ggplot(aes(x = DateTime, y = spread)) +
+    geom_line() +
+    geom_smooth() +
+    facet_wrap(.~country) +
+    ylim(c(NA, 500))
 
 
 ########## different system values for austria
@@ -191,7 +205,7 @@ list.csv.files <- c(PV_GIS_OPT,
                     PV_GIS_VERTICAL_SOUTH,
                     PV_GIS_TWO_AXIS)
 
-d.pv.gis <- read_csv(list_csv_files, skip=19, id="type") %>%
+d.pv.gis <- read_csv(list.csv.files, skip=19, id="type") %>%
     mutate(time=ymd_hm(time)) %>%
     mutate(type = str_remove(type, "pv-gis")) %>%
     mutate(type = str_remove(type, "\\.csv")) %>%
@@ -244,8 +258,6 @@ d.pv.gis.2018 %>%
     geom_line(aes(col=type)) +
     facet_wrap(.~month)
 
-
-
 d.join.prices.pv <- full_join(d.prices.filtered %>%
               filter(country == "AT"),
           d.pv.gis.2018,
@@ -294,6 +306,8 @@ d.join.prices.pv %>%
     theme_bw() +
     xlab("Month") +
     ylab("Cumulative income (€/kw_peak)")
+
+
 
 
 

--- a/analysis/value-renewables.R
+++ b/analysis/value-renewables.R
@@ -1,0 +1,87 @@
+library(tidyverse)
+rm(list = ls())
+#source("load/entsoe/_shared.r")
+source("_shared.r")
+source("calc/prediction-gas-consumption/_functions.r")
+
+d.generation = loadFromStorage(id = "electricity-generation-hourly")
+d.prices = loadFromStorage(id = "electricity-price-entsoe-hourly") %>%
+    mutate(country = substr(AreaName, 1,2))
+
+d.cap.fact <- d.generation %>%
+    filter(country %in% c("AT", "ES")) %>%
+    group_by(year = year(DateTime), source, country) %>%
+    mutate(cap_fact = value / max(value)) %>%
+    mutate(hour_of_year = 1:n()) %>%
+    ungroup()
+
+d.cap.fact %>%
+    filter(source %in% c("Solar", "Wind Onshore")) %>%
+    filter(year > 2014) %>%
+    ggplot(aes(x = DateTime, y = cap_fact)) +
+    geom_smooth(aes(col = source)) +
+    facet_wrap(. ~ country)
+
+d.prices.filtered <- d.prices %>%
+    mutate(year = year(DateTime)) %>%
+    filter(ResolutionCode == "PT60M") %>%
+    filter(year > 2018) %>%
+    filter(AreaName %in% c("AT BZN", "ES BZN")) %>%
+    arrange(DateTime)
+
+full_join(d.cap.fact,
+          d.prices.filtered,
+          by = c("DateTime" = "DateTime", "country" = "country")) %>%
+    filter(source %in% c("Solar", "Wind Onshore")) %>%
+    mutate(value = cap_fact * mean) %>%
+    mutate(month = month(DateTime)) %>%
+    mutate(year = year(DateTime)) %>%
+    filter(year > 2018) %>%
+    dplyr::select(year, month, DateTime, source, value, country) %>%
+    filter(! (source %in% c("Fossil Hard coal",
+                            "Other",
+                            "Other renewable",
+                            "Fossil Oil"))) %>%
+    filter(!is.na(source)) %>%
+    group_by(year, month, country, source) %>%
+    summarize(value = sum(value, na.rm = TRUE),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    group_by(country, source) %>%
+    mutate(rollvalue = rollsum(value, 12, fill = NA, align = "right") / 1000) %>%
+    ungroup() %>%
+    #na.omit() %>%
+    ggplot(aes(x = DateTime, y = rollvalue)) +
+    geom_line(aes(col = source)) +
+    facet_wrap(.~country)
+
+full_join(d.cap.fact,
+          d.prices.filtered,
+          by = c("DateTime" = "DateTime",
+                 "country" = "country")) %>%
+    filter(! (source %in% c("Fossil Hard coal",
+                            "Other",
+                            "Other renewable",
+                            "Fossil Oil",
+                            "Geothermal",
+                            "Waste",
+                            "Biomass"))) %>%
+    filter(source %in% c("Solar", "Wind Onshore", "Fossil Gas")) %>%
+    filter(!is.na(source)) %>%
+    mutate(value.power = value * mean) %>%
+    mutate(month = month(DateTime)) %>%
+    mutate(year = year(DateTime)) %>%
+    filter(year > 2018) %>%
+
+#    dplyr::select(year, month, DateTime, source, value) %>%
+    group_by(year, month, country, source) %>%
+    summarize(value = sum(value.power, na.rm = TRUE) / sum(value, na.rm = TRUE),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    ggplot(aes(x = DateTime, y = value)) +
+    geom_line(aes(col = source)) +
+    facet_wrap(.~country)
+    #geom_smooth(aes(col = source))
+    #facet_wrap(. ~ source) +
+    #ylim(c(0, 100))
+

--- a/analysis/value-renewables.rmd
+++ b/analysis/value-renewables.rmd
@@ -1,0 +1,164 @@
+---
+title: "Value renewables"
+output: html_document
+date: "2024-04-14"
+---
+
+```{r setup, include=FALSE}
+setwd("G:/Meine Ablage/drive-work/packages/energy-monitor-test/explore/")
+source("calc/setup-value-renewables.R")
+source("export/analysis/_theme.r")
+loadPackages(knitr)
+
+
+```
+
+## Entwicklung der Marktbedingungen für erneuerbare Energien
+
+
+
+Erneuerbare Energien, insbesondere Photovoltaik, wurden seit der Gaskrise 2022 in Österreich und Europa enorm ausgebaut. Auf dieser Seite zeigen wir, wie sich die Marktbedingungen für Wind, Photovoltaik und Batteriespeicher in Österreich und anderen europäischen Ländern entwickelt haben. 
+
+# Residual Load
+
+# Marktpreise
+Dafür zeigen wir als erstes die Preisentwicklungen in vier europäischen Strommärkten. In allen Märkten sind die Preise auf oder unter Vorkrisenniveau gefallen. In Spanien und Frankreich nähern sich die Preise im April 0€/MWh. Der Grund: die Produktion der erneuerbaren Energien führt dazu, dass in den meisten Stunden keine Produktion aus Gaskraftwerken notwendig ist - das ist ab April besonders sichtbar, da in diesem Monat die Photovoltaikproduktion stark ansteigt. Da die Grenzkosten von erneuerbaren Energien bei 0 liegen, fällt der Marktpreis sehr stark.  
+
+```{r market-prices}
+### VALUE ###
+d.prices.filtered %>% 
+    group_by(Jahr = year(DateTime), Monat = month(DateTime), Land = country) %>% 
+    summarize(Preis = mean(mean)) %>% 
+    ungroup() %>% 
+    mutate(Jahr = as.character(Jahr)) %>%
+    filter(Jahr > 2019) %>% 
+    ggplot(aes(x = Monat, y = Preis)) +
+    geom_line(aes(col = Jahr)) +
+    facet_wrap(. ~ Land) +
+    ylab("Durchschnittlicher Preis (€/MWh)") +
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1)))))
+```
+# Marktwert
+
+Durch den fallenden durchschnittlichen Marktpreis fällt auch der Wert, den Stromerzeugungstechnologien am Markt lukrieren können (2022 als Ausreisser wird nicht gezeigt). Für Spanien und Frankreich geht der Wert aller Technologien gegen 0 €/MWh , da ja auch der Marktpreis gegen 0 €/MWh tendiert. Für Österreich und Deutschland zeigt sich, dass Gas- und Windstrom den Marktwert stabil halten können. Für Photovoltaik sinkt er aber sehr stark. Das ergibt sich durch die hohe Gleichzeitigkeit der PV-Strom Produktion: diese ist vor allem untertags hochkonzentriert. Speisen alle Photovoltaikanlagen aber gleichzeitig ein, sinkt der Marktpreis sehr stark, oft gegen 0€/MWh.  
+
+```{r market-value}
+### VALUE ###
+full_join(d.gen.sel,
+          d.prices.filtered,
+          by = c("DateTime" = "DateTime",
+                 "country" = "country")) %>%
+    filter(source %in% c("Solar", "Wind Onshore", "Fossil Gas")) %>%
+    filter(!is.na(source)) %>%
+    mutate(value.power = value * mean) %>%
+    mutate(month = month(DateTime)) %>%
+    mutate(year = year(DateTime)) %>%
+    filter(year > 2019) %>%
+    filter(year != 2022) %>% 
+    group_by(year, month, country, source) %>%
+    summarize(value = sum(value.power, na.rm = TRUE) / sum(value, na.rm = TRUE),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    mutate(Technology = source) %>%
+    mutate(Jahr = as.character(year)) %>% 
+    ggplot(aes(x = month, y = value)) +
+    geom_line(aes(col = Jahr)) +
+    facet_grid(Technology~country) +
+    xlab("Monat") +
+    ylab("Durchschnittlicher Marktwert (€/MWh)") +
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) 
+
+
+```
+
+## Generiertes Einkommen
+
+Werden Erzeugungsanlagen durch Marktpreise kompensiert, können sie die unten dargestellten kumulativen Einkommen generieren (2022 als Ausreisser wird nicht gezeigt). 
+```{r income}
+full_join(d.prices.filtered,
+          ninja_pv,
+          by = c("t" = "t", "country" = "country")) %>%
+    full_join(ninja_wind,
+              by = c("t" = "t", "country" = "country")) %>%
+    gather(source, cap_fact, -DateTime, -year, -mean, -country, -t) %>%
+    mutate(value = cap_fact * mean) %>%
+    mutate(month = month(DateTime)) %>%
+    mutate(year = year(DateTime)) %>%
+    filter(year > 2018) %>%
+    dplyr::select(year, month, DateTime, source, value, country) %>%
+    group_by(year, country, source) %>%
+    mutate(value = cumsum(value) / 1000) %>%
+    mutate(Stunde = 1:n()) %>% 
+    ungroup() %>%
+#    filter(year < max(year) | (year == max(year) & month < month(max_date))) %>%
+    filter(year > 2018) %>% 
+    filter(year != 2022) %>% 
+    mutate(Monat = month(DateTime),
+           Jahr = as.character(year(DateTime))) %>% 
+    ggplot(aes(x = Stunde, y = value)) +
+    geom_line(aes(col = Jahr)) +
+    facet_grid(source~country, scale="free") +
+    ylab("Kumulatives Einkommen\n generiert durch 1KW Kapazität (€)")
+
+
+```
+
+## Einkommen durch Flexibilität
+```{r flexibility}
+d.prices.filtered %>%
+    mutate(day = yday(DateTime)) %>%
+    mutate(month = month(DateTime)) %>%
+    group_by(year, month, day, country) %>%
+    summarize(spread = max(mean) - min(mean),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    group_by(year, month, country) %>%
+    summarize(spread = mean(spread),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    mutate(Jahr = as.character(year)) %>% 
+    filter(year != 2022) %>% 
+    ggplot(aes(x = month, y = spread)) +
+    geom_line(aes(col = Jahr)) +
+    facet_wrap(.~country, scale = "free") +
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) 
+
+
+
+```
+
+d.prices.filtered %>%
+    mutate(day = yday(DateTime)) %>%
+    mutate(month = month(DateTime)) %>%
+    group_by(year, month, day, country) %>%
+    summarize(spread = max(mean) - min(mean),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    group_by(year, month, country) %>%
+    summarize(spread = mean(spread),
+              DateTime = min(DateTime)) %>%
+    ungroup() %>%
+    ggplot(aes(x = DateTime, y = spread)) +
+    geom_line() +
+    geom_smooth() +
+    facet_wrap(.~country) +
+    ylim(c(NA, 500))
+
+d.join.prices.pv %>%
+    filter(year > 2022) %>%
+    ggplot(aes(x = DateTime, y = rollvalue)) +
+    geom_line(aes(col = type)) +
+    #geom_smooth(aes(col = type), method = "gam")
+    ylab("Income for 1kw_peak (€/Month)") +
+    theme_bw()
+
+d.join.prices.pv %>%
+    group_by(year, type) %>%
+    mutate(c_value=cumsum(rollvalue)) %>%
+    ungroup() %>%
+    ggplot(aes(x = month(DateTime), y = c_value)) +
+    geom_line(aes(col = type)) +
+    facet_wrap(.~year) +
+    theme_bw() +
+    xlab("Month") +
+    ylab("Cumulative income (€/kw_peak)")

--- a/analysis/value-renewables.rmd
+++ b/analysis/value-renewables.rmd
@@ -21,7 +21,7 @@ Erneuerbare Energien, insbesondere Photovoltaik, wurden seit der Gaskrise 2022 i
 
 Als erstes zeigen wir die Residuallast: das ist jene Stromlast, die gedeckt werden muss, nachdem Wind-, Solar- und Laufwasserkraft abgezogen wurden. Diese Last muss aus anderen Quellen gedeckt werden, welche höhere Betriebskosten haben (z.b. Gaskraftwerke oder Wasserspeicher). Je niedriger diese Residuallast, umso niedrigere Strompreise sind zu erwarten, weil kaum teure Kraftwerke zugeschalten werden müssen.
 
-```{r market-prices}
+```{r residual-load}
 ### VALUE ###
 d.residual.wo.nuclear %>%
     group_by(Jahr = year(DateTime), Monat = month(DateTime), Land = country) %>% 
@@ -41,10 +41,11 @@ d.residual.wo.nuclear %>%
     ggtitle("Residuallast")
 ```
 
+
 ## Marktpreise, Marktwert und Einkommen
 Die relativ geringe Residuallast und der fallende Gaspreis spiegeln sich bei den Preisentwicklungen wider. In allen Märkten sind die Preise auf oder unter Vorkrisenniveau gefallen. In Spanien und Frankreich nähern sich die Preise im April bereits 0€/MWh - dort kann die im Betrieb sehr kostengünstige Nuklearkraft die Residuallast zu großen Teilen decken. Da das teuerste notwendige Kraftwerk den Preis setzt, fällt in Stunden, in denen Gaskraftwerke nicht notwendig sind, der Preis gegen 0€/MWh.
 
-```{r market-value}
+```{r market-prices}
 ### VALUE ###
 d.prices.filtered %>% 
     group_by(Jahr = year(DateTime), Monat = month(DateTime), Land = country) %>% 
@@ -66,7 +67,7 @@ d.prices.filtered %>%
 
 Durch den fallenden durchschnittlichen Marktpreis fällt auch der Wert, den Stromerzeugungstechnologien am Markt lukrieren können. Für Spanien und Frankreich geht der Wert aller Technologien gegen 0 €/MWh. Für Österreich und Deutschland zeigt sich, dass Gas- und in geringerem Umfang auch Windstrom den Marktwert stabil halten können. Für Photovoltaik sinkt er aber sehr stark. Das ergibt sich durch die hohe Gleichzeitigkeit der PV-Strom Produktion: diese ist vor allem untertags hochkonzentriert. Speisen alle Photovoltaikanlagen aber gleichzeitig ein, sinkt der Marktpreis sehr stark, oft gegen 0€/MWh oder sogar auf negative Werte.
 
-```{r market-value-cumulative}
+```{r market-value}
 ### VALUE ###
 full_join(d.gen.sel,
           d.prices.filtered,

--- a/analysis/value-renewables.rmd
+++ b/analysis/value-renewables.rmd
@@ -13,7 +13,6 @@ knitr::opts_chunk$set(
     fig.height = 8
 )
 
-
 ```
 
 # Entwicklung der Marktbedingungen für erneuerbare Energien
@@ -49,7 +48,7 @@ Die relativ geringe Residuallast und der fallende Gaspreis spiegeln sich bei den
 ### VALUE ###
 d.prices.filtered %>% 
     group_by(Jahr = year(DateTime), Monat = month(DateTime), Land = country) %>% 
-    summarize(Preis = mean(mean)) %>% 
+    summarize(Preis = mean(price)) %>% 
     ungroup() %>% 
     mutate(Jahr = as.character(Jahr)) %>%
     filter(Jahr > 2018) %>% 
@@ -75,7 +74,7 @@ full_join(d.gen.sel,
                  "country" = "country")) %>%
     filter(source %in% c("Solar", "Wind Onshore", "Fossil Gas")) %>%
     filter(!is.na(source)) %>%
-    mutate(value.power = value * mean) %>%
+    mutate(value.power = value * price) %>%
     mutate(month = month(DateTime)) %>%
     mutate(year = year(DateTime)) %>%
     filter(year > 2019) %>%
@@ -108,8 +107,8 @@ full_join(d.prices.filtered,
           by = c("t" = "t", "country" = "country")) %>%
     full_join(ninja_wind,
               by = c("t" = "t", "country" = "country")) %>%
-    gather(source, cap_fact, -DateTime, -year, -mean, -country, -t) %>%
-    mutate(value = cap_fact * mean) %>%
+    gather(source, cap_fact, -DateTime, -year, -price, -country, -t) %>%
+    mutate(value = cap_fact * price) %>%
     mutate(month = month(DateTime)) %>%
     mutate(year = year(DateTime)) %>%
     dplyr::select(year, month, DateTime, source, value, country) %>%
@@ -143,7 +142,7 @@ d.prices.filtered %>%
     mutate(day = yday(DateTime)) %>%
     mutate(month = month(DateTime)) %>%
     group_by(year, month, day, country) %>%
-    summarize(spread = max(mean) - min(mean),
+    summarize(spread = max(price) - min(price),
               DateTime = min(DateTime)) %>%
     ungroup() %>%
     group_by(year, month, country) %>%
@@ -172,7 +171,7 @@ d.prices.filtered %>%
     mutate(day = yday(DateTime)) %>%
     mutate(month = month(DateTime)) %>%
     group_by(year, month, day, country) %>%
-    summarize(spread = max(mean) - min(mean),
+    summarize(spread = max(price) - min(price),
               DateTime = min(DateTime)) %>%
     ungroup() %>%
     group_by(year, country) %>%

--- a/analysis/value-renewables.rmd
+++ b/analysis/value-renewables.rmd
@@ -5,7 +5,6 @@ date: "2024-04-14"
 ---
 
 ```{r setup, include=FALSE}
-setwd("G:/Meine Ablage/drive-work/packages/energy-monitor-test/explore/")
 source("calc/setup-value-renewables.R")
 source("export/analysis/_theme.r")
 loadPackages(knitr)

--- a/analysis/value-renewables.rmd
+++ b/analysis/value-renewables.rmd
@@ -20,6 +20,66 @@ loadPackages(knitr)
 Erneuerbare Energien, insbesondere Photovoltaik, wurden seit der Gaskrise 2022 in Österreich und Europa enorm ausgebaut. Auf dieser Seite zeigen wir, wie sich die Marktbedingungen für Wind, Photovoltaik und Batteriespeicher in Österreich und anderen europäischen Ländern entwickelt haben. 
 
 # Residual Load
+```{r market-prices}
+### VALUE ###
+setwd("G:/Meine Ablage/drive-work/packages/energy-monitor-test/explore/")
+d.generation = loadFromStorage(id = "electricity-generation-hourly")
+
+d.load = loadFromStorage(id = "electricity-load-hourly-res") %>%
+    filter(country %in% COUNTRIES)
+
+d.gen.sel <- d.generation %>%
+    filter(country %in% COUNTRIES) %>%
+    group_by(year = year(DateTime), source, country) %>%
+    mutate(hour_of_year = 1:n()) %>%
+    ungroup()
+
+d.gen.sel.ren <- d.gen.sel %>%
+    filter(source %in% c("Wind Onshore",
+                         "Solar",
+                         "Hydro Run-of-river and poundage",
+                         "Nuclear",
+                         "Wind Offshore")) %>%
+    group_by(DateTime, country) %>%
+    summarize(generation = sum(value, na.rm = TRUE))
+
+d.gen.sel.ren.wo.nuclear <- d.gen.sel %>%
+    filter(source %in% c("Wind Onshore",
+                         "Solar",
+                         "Hydro Run-of-river and poundage",
+                         "Wind Offshore")) %>%
+    group_by(DateTime, country) %>%
+    summarize(generation = sum(value, na.rm = TRUE))
+
+#### TODO FIX ERROR JOIN!!!!
+d.residual <- d.gen.sel.ren %>%
+    dplyr::select(DateTime, country, generation)  %>%
+    full_join(d.load %>% dplyr::select(DateTime, country, value), by = c("DateTime" = "DateTime", "country" = "country")) %>%
+    mutate(residual = value - generation)
+
+d.residual.wo.nuclear <- d.gen.sel.ren.wo.nuclear %>%
+    mutate(value = ifelse(is.na(generation), 0, generation)) %>%
+    dplyr::select(DateTime, country, generation)  %>%
+    full_join(d.load %>% dplyr::select(DateTime, country, value), by = c("DateTime" = "DateTime", "country" = "country")) %>%
+    mutate(residual = value - generation)
+
+
+d.residual %>%
+    group_by(Jahr = year(DateTime), Monat = month(DateTime), Land = country) %>% 
+    summarize(residual = mean(residual, na.rm = TRUE)) %>% 
+    ungroup() %>% 
+    mutate(Jahr = as.character(Jahr)) %>%
+    filter(Jahr > 2017) %>% 
+    #filter(Jahr != 2022) %>% 
+    mutate(is_2024 = ifelse(Jahr == 2024, "2024", "Nicht 2024")) %>% 
+    ggplot(aes(x = Monat, y = residual / 1000)) +
+    geom_line(aes(col = Jahr, linewidth = is_2024)) +
+    facet_wrap(. ~ Land, scale = "free") +
+    ylab("Durchschnittliche Residuallast (GW)") +
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) +
+    scale_linewidth_manual(values = c(1.4, 0.4)) +
+    guides(linewidth = FALSE)  
+```
 
 # Marktpreise
 Dafür zeigen wir als erstes die Preisentwicklungen in vier europäischen Strommärkten. In allen Märkten sind die Preise auf oder unter Vorkrisenniveau gefallen. In Spanien und Frankreich nähern sich die Preise im April 0€/MWh. Der Grund: die Produktion der erneuerbaren Energien führt dazu, dass in den meisten Stunden keine Produktion aus Gaskraftwerken notwendig ist - das ist ab April besonders sichtbar, da in diesem Monat die Photovoltaikproduktion stark ansteigt. Da die Grenzkosten von erneuerbaren Energien bei 0 liegen, fällt der Marktpreis sehr stark.  
@@ -32,11 +92,15 @@ d.prices.filtered %>%
     ungroup() %>% 
     mutate(Jahr = as.character(Jahr)) %>%
     filter(Jahr > 2019) %>% 
+    #filter(Jahr != 2022) %>% 
+    mutate(is_2024 = ifelse(Jahr == 2024, "2024", "Nicht 2024")) %>% 
     ggplot(aes(x = Monat, y = Preis)) +
-    geom_line(aes(col = Jahr)) +
-    facet_wrap(. ~ Land) +
+    geom_line(aes(col = Jahr, linewidth = is_2024)) +
+    facet_wrap(. ~ Land, scale = "free") +
     ylab("Durchschnittlicher Preis (€/MWh)") +
-    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1)))))
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) +
+    scale_linewidth_manual(values = c(1.4, 0.4)) +
+    guides(linewidth = FALSE)  
 ```
 # Marktwert
 
@@ -54,19 +118,22 @@ full_join(d.gen.sel,
     mutate(month = month(DateTime)) %>%
     mutate(year = year(DateTime)) %>%
     filter(year > 2019) %>%
-    filter(year != 2022) %>% 
+    #filter(year != 2022) %>% 
     group_by(year, month, country, source) %>%
     summarize(value = sum(value.power, na.rm = TRUE) / sum(value, na.rm = TRUE),
               DateTime = min(DateTime)) %>%
     ungroup() %>%
     mutate(Technology = source) %>%
+    mutate(is_2024 = ifelse(year == 2024, "2024", "Nicht 2024")) %>% 
     mutate(Jahr = as.character(year)) %>% 
     ggplot(aes(x = month, y = value)) +
-    geom_line(aes(col = Jahr)) +
+    geom_line(aes(col = Jahr, linewidth = is_2024)) +
     facet_grid(Technology~country) +
     xlab("Monat") +
     ylab("Durchschnittlicher Marktwert (€/MWh)") +
-    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) 
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1)))))  +
+    scale_linewidth_manual(values = c(1.4, 0.4)) +
+    guides(linewidth = FALSE)  
 
 
 ```
@@ -84,7 +151,6 @@ full_join(d.prices.filtered,
     mutate(value = cap_fact * mean) %>%
     mutate(month = month(DateTime)) %>%
     mutate(year = year(DateTime)) %>%
-    filter(year > 2018) %>%
     dplyr::select(year, month, DateTime, source, value, country) %>%
     group_by(year, country, source) %>%
     mutate(value = cumsum(value) / 1000) %>%
@@ -92,13 +158,15 @@ full_join(d.prices.filtered,
     ungroup() %>%
 #    filter(year < max(year) | (year == max(year) & month < month(max_date))) %>%
     filter(year > 2018) %>% 
-    filter(year != 2022) %>% 
+    mutate(is_2024 = ifelse(year == 2024, "2024", "Nicht 2024")) %>% 
     mutate(Monat = month(DateTime),
            Jahr = as.character(year(DateTime))) %>% 
     ggplot(aes(x = Stunde, y = value)) +
-    geom_line(aes(col = Jahr)) +
+    geom_line(aes(col = Jahr, linewidth = is_2024)) +
     facet_grid(source~country, scale="free") +
-    ylab("Kumulatives Einkommen\n generiert durch 1KW Kapazität (€)")
+    ylab("Kumulatives Einkommen\n generiert durch 1KW Kapazität (€)") +
+    scale_linewidth_manual(values = c(1.4, 0.4)) +
+    guides(linewidth = FALSE)  
 
 
 ```
@@ -117,16 +185,20 @@ d.prices.filtered %>%
               DateTime = min(DateTime)) %>%
     ungroup() %>%
     mutate(Jahr = as.character(year)) %>% 
-    filter(year != 2022) %>% 
+    mutate(is_2024 = ifelse(year == 2024, "2024", "Nicht 2024")) %>% 
     ggplot(aes(x = month, y = spread)) +
-    geom_line(aes(col = Jahr)) +
+    geom_line(aes(col = Jahr, linewidth = is_2024)) +
     facet_wrap(.~country, scale = "free") +
-    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) 
-
-
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) +
+    scale_linewidth_manual(values = c(1.4, 0.4)) +
+    guides(linewidth = FALSE) +
+    ylab("Monthly average of maximum daily spread (€/MWh)") +
+    xlab("Monat") +
+    ylab("Monatliches Mittel des maximaler täglichen Spreads (€/MWh)")
 
 ```
-
+# kumulatives einkommen flexibilität
+```{r flexibility-cumulative}
 d.prices.filtered %>%
     mutate(day = yday(DateTime)) %>%
     mutate(month = month(DateTime)) %>%
@@ -134,24 +206,24 @@ d.prices.filtered %>%
     summarize(spread = max(mean) - min(mean),
               DateTime = min(DateTime)) %>%
     ungroup() %>%
-    group_by(year, month, country) %>%
-    summarize(spread = mean(spread),
-              DateTime = min(DateTime)) %>%
+    group_by(year, country) %>%
+    mutate(spread = cumsum(spread)) %>%
     ungroup() %>%
-    ggplot(aes(x = DateTime, y = spread)) +
-    geom_line() +
-    geom_smooth() +
-    facet_wrap(.~country) +
-    ylim(c(NA, 500))
+    mutate(Jahr = as.character(year)) %>% 
+    mutate(is_2024 = ifelse(year == 2024, "2024", "Nicht 2024")) %>% 
+    ggplot(aes(x = day, y = spread)) +
+    geom_line(aes(col = Jahr, linewidth = is_2024)) +
+    facet_wrap(.~country, scale = "free") +
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) +
+    scale_linewidth_manual(values = c(1.4, 0.4)) +
+    guides(linewidth = FALSE)  +
+    xlab("Tag des Jahres") +
+    ylab("Kumulativer maximaler täglicher Spread (€/MWh)")
 
-d.join.prices.pv %>%
-    filter(year > 2022) %>%
-    ggplot(aes(x = DateTime, y = rollvalue)) +
-    geom_line(aes(col = type)) +
-    #geom_smooth(aes(col = type), method = "gam")
-    ylab("Income for 1kw_peak (€/Month)") +
-    theme_bw()
+```
 
+# ausrichtung von pv als flexibilitätsmaßnahme
+```{r flexibility-cumulative}
 d.join.prices.pv %>%
     group_by(year, type) %>%
     mutate(c_value=cumsum(rollvalue)) %>%
@@ -160,5 +232,9 @@ d.join.prices.pv %>%
     geom_line(aes(col = type)) +
     facet_wrap(.~year) +
     theme_bw() +
-    xlab("Month") +
-    ylab("Cumulative income (€/kw_peak)")
+    xlab("Monat") +
+    ylab("Kumulatives Einkommen (€/kw_peak)")
+
+```
+
+

--- a/analysis/value-renewables.rmd
+++ b/analysis/value-renewables.rmd
@@ -9,62 +9,22 @@ setwd("G:/Meine Ablage/drive-work/packages/energy-monitor-test/explore/")
 source("calc/setup-value-renewables.R")
 source("export/analysis/_theme.r")
 loadPackages(knitr)
+knitr::opts_chunk$set(
+    fig.height = 8
+)
 
 
 ```
 
-## Entwicklung der Marktbedingungen für erneuerbare Energien
+# Entwicklung der Marktbedingungen für erneuerbare Energien
 
+Erneuerbare Energien, insbesondere Photovoltaik, wurden seit der Gaskrise 2022 in Österreich und Europa enorm ausgebaut. Auf dieser Seite zeigen wir, wie sich die Großhandelsbedingungen für Wind, Photovoltaik und Batteriespeicher in Österreich und anderen europäischen Ländern entwickelt haben. An dieser Stelle betonen wir, dass vor allem dezentrale Stromerzeugungstechnologien wie Photovoltaik und Batteriespeicher auch zusätzlich Einkommen erzielen können (durch Wegfallen von Netzkosten oder durch Systemdienstleistungen). Dies wird hier im Weiteren nicht berücksichtigt, wir beschränken uns auf eine Analyse der Einkommenseffekte im Großhandel.
 
+Als erstes zeigen wir die Residuallast: das ist jene Stromlast, die gedeckt werden muss, nachdem Wind-, Solar- und Laufwasserkraft abgezogen wurden. Diese Last muss aus anderen Quellen gedeckt werden, welche höhere Betriebskosten haben (z.b. Gaskraftwerke oder Wasserspeicher). Je niedriger diese Residuallast, umso niedrigere Strompreise sind zu erwarten, weil kaum teure Kraftwerke zugeschalten werden müssen.
 
-Erneuerbare Energien, insbesondere Photovoltaik, wurden seit der Gaskrise 2022 in Österreich und Europa enorm ausgebaut. Auf dieser Seite zeigen wir, wie sich die Marktbedingungen für Wind, Photovoltaik und Batteriespeicher in Österreich und anderen europäischen Ländern entwickelt haben. 
-
-# Residual Load
 ```{r market-prices}
 ### VALUE ###
-setwd("G:/Meine Ablage/drive-work/packages/energy-monitor-test/explore/")
-d.generation = loadFromStorage(id = "electricity-generation-hourly")
-
-d.load = loadFromStorage(id = "electricity-load-hourly-res") %>%
-    filter(country %in% COUNTRIES)
-
-d.gen.sel <- d.generation %>%
-    filter(country %in% COUNTRIES) %>%
-    group_by(year = year(DateTime), source, country) %>%
-    mutate(hour_of_year = 1:n()) %>%
-    ungroup()
-
-d.gen.sel.ren <- d.gen.sel %>%
-    filter(source %in% c("Wind Onshore",
-                         "Solar",
-                         "Hydro Run-of-river and poundage",
-                         "Nuclear",
-                         "Wind Offshore")) %>%
-    group_by(DateTime, country) %>%
-    summarize(generation = sum(value, na.rm = TRUE))
-
-d.gen.sel.ren.wo.nuclear <- d.gen.sel %>%
-    filter(source %in% c("Wind Onshore",
-                         "Solar",
-                         "Hydro Run-of-river and poundage",
-                         "Wind Offshore")) %>%
-    group_by(DateTime, country) %>%
-    summarize(generation = sum(value, na.rm = TRUE))
-
-#### TODO FIX ERROR JOIN!!!!
-d.residual <- d.gen.sel.ren %>%
-    dplyr::select(DateTime, country, generation)  %>%
-    full_join(d.load %>% dplyr::select(DateTime, country, value), by = c("DateTime" = "DateTime", "country" = "country")) %>%
-    mutate(residual = value - generation)
-
-d.residual.wo.nuclear <- d.gen.sel.ren.wo.nuclear %>%
-    mutate(value = ifelse(is.na(generation), 0, generation)) %>%
-    dplyr::select(DateTime, country, generation)  %>%
-    full_join(d.load %>% dplyr::select(DateTime, country, value), by = c("DateTime" = "DateTime", "country" = "country")) %>%
-    mutate(residual = value - generation)
-
-
-d.residual %>%
+d.residual.wo.nuclear %>%
     group_by(Jahr = year(DateTime), Monat = month(DateTime), Land = country) %>% 
     summarize(residual = mean(residual, na.rm = TRUE)) %>% 
     ungroup() %>% 
@@ -78,35 +38,36 @@ d.residual %>%
     ylab("Durchschnittliche Residuallast (GW)") +
     scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) +
     scale_linewidth_manual(values = c(1.4, 0.4)) +
-    guides(linewidth = FALSE)  
+    guides(linewidth = FALSE) +
+    ggtitle("Residuallast")
 ```
 
-# Marktpreise
-Dafür zeigen wir als erstes die Preisentwicklungen in vier europäischen Strommärkten. In allen Märkten sind die Preise auf oder unter Vorkrisenniveau gefallen. In Spanien und Frankreich nähern sich die Preise im April 0€/MWh. Der Grund: die Produktion der erneuerbaren Energien führt dazu, dass in den meisten Stunden keine Produktion aus Gaskraftwerken notwendig ist - das ist ab April besonders sichtbar, da in diesem Monat die Photovoltaikproduktion stark ansteigt. Da die Grenzkosten von erneuerbaren Energien bei 0 liegen, fällt der Marktpreis sehr stark.  
+## Marktpreise, Marktwert und Einkommen
+Die relativ geringe Residuallast und der fallende Gaspreis spiegeln sich bei den Preisentwicklungen wider. In allen Märkten sind die Preise auf oder unter Vorkrisenniveau gefallen. In Spanien und Frankreich nähern sich die Preise im April bereits 0€/MWh - dort kann die im Betrieb sehr kostengünstige Nuklearkraft die Residuallast zu großen Teilen decken. Da das teuerste notwendige Kraftwerk den Preis setzt, fällt in Stunden, in denen Gaskraftwerke nicht notwendig sind, der Preis gegen 0€/MWh.
 
-```{r market-prices}
+```{r market-value}
 ### VALUE ###
 d.prices.filtered %>% 
     group_by(Jahr = year(DateTime), Monat = month(DateTime), Land = country) %>% 
     summarize(Preis = mean(mean)) %>% 
     ungroup() %>% 
     mutate(Jahr = as.character(Jahr)) %>%
-    filter(Jahr > 2019) %>% 
+    filter(Jahr > 2018) %>% 
     #filter(Jahr != 2022) %>% 
     mutate(is_2024 = ifelse(Jahr == 2024, "2024", "Nicht 2024")) %>% 
     ggplot(aes(x = Monat, y = Preis)) +
     geom_line(aes(col = Jahr, linewidth = is_2024)) +
-    facet_wrap(. ~ Land, scale = "free") +
+    facet_wrap(. ~ Land) +
     ylab("Durchschnittlicher Preis (€/MWh)") +
     scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) +
     scale_linewidth_manual(values = c(1.4, 0.4)) +
-    guides(linewidth = FALSE)  
+    guides(linewidth = FALSE) +
+    ggtitle("Durchschnittlicher Marktpreis")
 ```
-# Marktwert
 
-Durch den fallenden durchschnittlichen Marktpreis fällt auch der Wert, den Stromerzeugungstechnologien am Markt lukrieren können (2022 als Ausreisser wird nicht gezeigt). Für Spanien und Frankreich geht der Wert aller Technologien gegen 0 €/MWh , da ja auch der Marktpreis gegen 0 €/MWh tendiert. Für Österreich und Deutschland zeigt sich, dass Gas- und Windstrom den Marktwert stabil halten können. Für Photovoltaik sinkt er aber sehr stark. Das ergibt sich durch die hohe Gleichzeitigkeit der PV-Strom Produktion: diese ist vor allem untertags hochkonzentriert. Speisen alle Photovoltaikanlagen aber gleichzeitig ein, sinkt der Marktpreis sehr stark, oft gegen 0€/MWh.  
+Durch den fallenden durchschnittlichen Marktpreis fällt auch der Wert, den Stromerzeugungstechnologien am Markt lukrieren können. Für Spanien und Frankreich geht der Wert aller Technologien gegen 0 €/MWh. Für Österreich und Deutschland zeigt sich, dass Gas- und in geringerem Umfang auch Windstrom den Marktwert stabil halten können. Für Photovoltaik sinkt er aber sehr stark. Das ergibt sich durch die hohe Gleichzeitigkeit der PV-Strom Produktion: diese ist vor allem untertags hochkonzentriert. Speisen alle Photovoltaikanlagen aber gleichzeitig ein, sinkt der Marktpreis sehr stark, oft gegen 0€/MWh oder sogar auf negative Werte.
 
-```{r market-value}
+```{r market-value-cumulative}
 ### VALUE ###
 full_join(d.gen.sel,
           d.prices.filtered,
@@ -133,14 +94,14 @@ full_join(d.gen.sel,
     ylab("Durchschnittlicher Marktwert (€/MWh)") +
     scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1)))))  +
     scale_linewidth_manual(values = c(1.4, 0.4)) +
-    guides(linewidth = FALSE)  
+    guides(linewidth = FALSE) +
+    ggtitle("Marktwert von Stromproduktionstechnologien")
 
 
 ```
 
-## Generiertes Einkommen
+Wieviel Einkommen kann erzielt werden, wenn der Strom an der Börse verkauft wird? Die Grafik zeigt die kumulativen Einnahmen aus dem Verkauf von PV und Windstrom für verschiedene Jahre, normiert auf 1kw installierte Kapazität der entsprechenden Technologie (Hinweis: hier wird die Wind- und PV-Produktion eines typischen Jahres verwendet, anstatt der tatsächlichen Produktion). Hier zeigt sich, dass die Einnahmen in der Periode 2021-2023 außergewöhnlich hoch waren. So hätte man alleine mit den Einnahmen aus dem Jahr 2022 die Installationskosten für 1KW PV zur Hälfte finanzieren können. Diese Situation hat sich geändert: trotz gesunkener PV Preise braucht es zumindest 10 Jahre, um die Kosten zurückzuverdienen.
 
-Werden Erzeugungsanlagen durch Marktpreise kompensiert, können sie die unten dargestellten kumulativen Einkommen generieren (2022 als Ausreisser wird nicht gezeigt). 
 ```{r income}
 full_join(d.prices.filtered,
           ninja_pv,
@@ -163,15 +124,20 @@ full_join(d.prices.filtered,
            Jahr = as.character(year(DateTime))) %>% 
     ggplot(aes(x = Stunde, y = value)) +
     geom_line(aes(col = Jahr, linewidth = is_2024)) +
-    facet_grid(source~country, scale="free") +
+    facet_grid(source~country) +
     ylab("Kumulatives Einkommen\n generiert durch 1KW Kapazität (€)") +
     scale_linewidth_manual(values = c(1.4, 0.4)) +
-    guides(linewidth = FALSE)  
+    guides(linewidth = FALSE) +
+    ggtitle("Hypothetisches Einkommen aus PV und Wind")
 
 
 ```
 
 ## Einkommen durch Flexibilität
+
+## Anreize für Flexibilität
+Aber sollte in Folge des Ausbaus der erneuerbaren Energien am Markt nicht der Anreiz erhöht werdne, in Flexibilität zu investieren, da in manchen Stunden der Preis hoch, in anderen aber niedrig ist? Durch den vermehrten Ausbau von Photovoltaik sollte genau dieser Effekt eintreten. Die Grafik unten zeigt, wie hoch der Preisunterschied zwischen der billigsten und teuersten Stunde an einem Tag in €/MWh ist. In der Näherung ist das der Betrag, den ein - verlustfreier - Batteriespeicher mit einer Größe von 1 MWh verdienen kann. Hier zeigt sich, dass für Deutschland und Österreich im Jahr 2024 der Wert steigt. Er nähert sich dabei noch nicht dem Maximalwert von 2022 an, ist aber über 2023, einem Jahr, in dem die Gaspreise noch deutlich höher waren. Für Spanien und Frankreich ist der Anreiz aber sehr gering, hierfür könnte der hohe Anteil von Atomkraft in Frankreich verantwortlich sein. Diese kann auch in Zeiten, in denen wenige erneuerbare Energien zur Verfügung stehen, kostengünstigen Storm zur Verfügung stellen, was die Preise senkt.
+
 ```{r flexibility}
 d.prices.filtered %>%
     mutate(day = yday(DateTime)) %>%
@@ -188,16 +154,19 @@ d.prices.filtered %>%
     mutate(is_2024 = ifelse(year == 2024, "2024", "Nicht 2024")) %>% 
     ggplot(aes(x = month, y = spread)) +
     geom_line(aes(col = Jahr, linewidth = is_2024)) +
-    facet_wrap(.~country, scale = "free") +
+    facet_wrap(.~country) +
     scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) +
     scale_linewidth_manual(values = c(1.4, 0.4)) +
     guides(linewidth = FALSE) +
     ylab("Monthly average of maximum daily spread (€/MWh)") +
     xlab("Monat") +
-    ylab("Monatliches Mittel des maximaler täglichen Spreads (€/MWh)")
+    ylab("Monatliches Mittel des \nmaximalen täglichen Spreads (€/MWh)") +
+    ggtitle("Hypothetisches Einkommen aus 1MWh Speicher")
 
 ```
-# kumulatives einkommen flexibilität
+
+Diese hypothetischen täglichen Einkommen aufsummiert über ein ganzes Jahr können dabei helfen, die Profitabilität eines Speichers einzuschätzen. Bei derzeitigen Großspeicherkosten ist ein break-even bei Jahreseinkommen von knapp 20.000€ zu erwarten. Die Grafik zeigt, dass dieses Einkommen in den Krisenjahre 2021-2023 in Österreich und Deutschland zu erzielen war, für 2024 zeichnet sich für diese Region ein ähnlicher Trend ab. Für Spanien und Frankreich sind die Preisunterschiede aber zu gering, um Speicher zu finanzieren.
+
 ```{r flexibility-cumulative}
 d.prices.filtered %>%
     mutate(day = yday(DateTime)) %>%
@@ -213,28 +182,31 @@ d.prices.filtered %>%
     mutate(is_2024 = ifelse(year == 2024, "2024", "Nicht 2024")) %>% 
     ggplot(aes(x = day, y = spread)) +
     geom_line(aes(col = Jahr, linewidth = is_2024)) +
-    facet_wrap(.~country, scale = "free") +
+    facet_wrap(.~country) +
     scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))) +
     scale_linewidth_manual(values = c(1.4, 0.4)) +
     guides(linewidth = FALSE)  +
     xlab("Tag des Jahres") +
-    ylab("Kumulativer maximaler täglicher Spread (€/MWh)")
+    ylab("Kumulativer maximaler \ntäglicher Spread (€/MWh)") +
+    ggtitle("Kumulativer Ertrag von 1 MWh Speicher")
 
 ```
-
-# ausrichtung von pv als flexibilitätsmaßnahme
-```{r flexibility-cumulative}
+Eine andere Form, den Wert von Strom aus Photovoltaik zu erhöhen, könnte eine unterschiedliche Ausrichtung der Systeme sein. So produziert eine Ost-West Ausrichtung zwar weniger Strom, aber tendenziell zu Tageszeiten wenn der Strom teurer ist. Zur Zeit ist dieser Effekt allerdings noch nicht groß genug: die Grafik zeigt den durchschnittlichen monetären Ertrag unterschiedlicher Ausrichtungen von PV-Anlagen in Österreich. Ein Tracking-System (two.axis) hat immer den optimalen Erlös, da es zu jeder Tageszeit den optimalen Ertrag haben kann. Eine Ertragsoptimierende Ausrichtung (opt.opt) folgt aber ein zweiter Stelle: obwohl das Profil hochkorreliert ist mit anderen PV-Anlagen mit der gleichen Ausrichtung, kann in Summe über dieses System (noch) am meisten Einkommen lukriert werden. Optimal geneigte Ost-West Anlagen (angle.east.west) erzeugen aber ähnlich hohe Einkommen. Vertikale PV-Anlagen, wie sie oft als Balkon PV-Anlagen zum Einsatz kommen, haben bei reiner Südausrichtung (vertical.south) vertretbare Erträge, werden diese aber Ost-West (vertical.east.west) oder gar Nord-Süd (vertical.north.south) ausgerichtet, sinkt der Ertrag beträchtlich. Noch zahlt sich eine bewusste Neuausrichtung von Anlagen zur Maximierung des Werts - und nicht des Stromertrags - also noch nicht aus.
+ 
+```{r flexibility-pv}
 d.join.prices.pv %>%
     group_by(year, type) %>%
     mutate(c_value=cumsum(rollvalue)) %>%
     ungroup() %>%
+    mutate(Ausrichtung = type) %>% 
+    na.omit() %>% 
     ggplot(aes(x = month(DateTime), y = c_value)) +
-    geom_line(aes(col = type)) +
+    geom_line(aes(col = Ausrichtung)) +
     facet_wrap(.~year) +
     theme_bw() +
     xlab("Monat") +
-    ylab("Kumulatives Einkommen (€/kw_peak)")
+    ylab("Kumulatives Einkommen (€/kw_peak)") +
+    ggtitle("Ertrag von PV Anlagen mit unterschiedlichen Ausrichtungen in Österreich") +
+    scale_x_continuous(breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1)))))
 
 ```
-
-

--- a/analysis/value-renewables.rmd
+++ b/analysis/value-renewables.rmd
@@ -1,6 +1,6 @@
 ---
 title: "Value renewables"
-output: html_document
+output: md_document
 date: "2024-04-14"
 ---
 

--- a/calc/setup-value-renewables.R
+++ b/calc/setup-value-renewables.R
@@ -1,4 +1,4 @@
-rm(list = ls())
+# - INIT -----------------------------------------------------------------------
 source("_shared.r")
 loadPackages('tidyverse')
 

--- a/calc/setup-value-renewables.R
+++ b/calc/setup-value-renewables.R
@@ -138,7 +138,6 @@ d.residual.wo.nuclear <- d.gen.sel.ren.wo.nuclear %>%
 
 d.prices.filtered <- d.prices %>%
     mutate(year = year(DateTime)) %>%
-    filter(ResolutionCode == "PT60M") %>%
     filter(year > 2018) %>%
     filter(country %in% COUNTRIES) %>%
     arrange(DateTime) %>%

--- a/calc/setup-value-renewables.R
+++ b/calc/setup-value-renewables.R
@@ -2,8 +2,7 @@ rm(list = ls())
 source("_shared.r")
 loadPackages('tidyverse')
 
-download_ninja = TRUE
-download_pv_gis = TRUE
+NINJA_DIR <- "data/ninja/"
 
 PV_FILE_NINJA <- "data/ninja/pv.zip"
 PV_GIS_OPT = "data/ninja/pv-gis-opt-opt.csv"
@@ -15,49 +14,67 @@ PV_GIS_VERTICAL_NORTH = "data/ninja/pv-gis-vertical-north.csv"
 PV_GIS_VERTICAL_SOUTH = "data/ninja/pv-gis-vertical-south.csv"
 PV_GIS_TWO_AXIS = "data/ninja/pv-gis-two-axis.csv"
 
-if(file.exists(PV_FILE_NINJA)) {
+download_ninja = TRUE
+download_pv_gis = TRUE
+
+if (file.exists(PV_FILE_NINJA)) {
     download_ninja = FALSE
 }
 
-if(file.exists(PV_GIS_OPT)) {
+if (file.exists(PV_GIS_OPT)) {
     download_pv_gis = FALSE
 }
 
-if(download_ninja){
+if (download_ninja) {
     PV_FILE <- PV_FILE_NINJA
     WIND_FILE <- "data/ninja/wind.zip"
-    EX_DIR <- "data/ninja/"
-    download.file("https://renewables.ninja/downloads/ninja_europe_pv_v1.1.zip",
-              PV_FILE)
 
-    options(timeout=120)
+    download.file("https://renewables.ninja/downloads/ninja_europe_pv_v1.1.zip",
+                  PV_FILE)
+
+    options(timeout = 120)
     download.file("https://renewables.ninja/downloads/ninja_europe_wind_v1.1.zip",
-              WIND_FILE)
-    unzip(PV_FILE, exdir = EX_DIR)
-    unzip(WIND_FILE, exdir = EX_DIR)
+                  WIND_FILE)
+    unzip(PV_FILE, exdir = NINJA_DIR)
+    unzip(WIND_FILE, exdir = NINJA_DIR)
 }
 
-if(download_pv_gis){
+if (download_pv_gis) {
+    download.file(
+        "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&optimalangles=1",
+        PV_GIS_OPT
+    )
+    download.file(
+        "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=38&aspect=-90",
+        PV_GIS_EAST
+    )
+    download.file(
+        "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=38&aspect=90",
+        PV_GIS_WEST
+    )
+    download.file(
+        "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=-90",
+        PV_GIS_VERTICAL_EAST
+    )
+    download.file(
+        "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=90",
+        PV_GIS_VERTICAL_WEST
+    )
 
-    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&optimalangles=1",
-                  PV_GIS_OPT)
-    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=38&aspect=-90",
-                  PV_GIS_EAST)
-    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=38&aspect=90",
-                  PV_GIS_WEST)
-    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=-90",
-                  PV_GIS_VERTICAL_EAST)
-    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=90",
-                  PV_GIS_VERTICAL_WEST)
+    download.file(
+        "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=0",
+        PV_GIS_VERTICAL_SOUTH
+    )
 
-    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=0",
-                  PV_GIS_VERTICAL_SOUTH)
+    download.file(
+        "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=180",
+        PV_GIS_VERTICAL_NORTH
+    )
 
-    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&angle=90&aspect=180",
-                  PV_GIS_VERTICAL_NORTH)
-
-    download.file("https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&trackingtype=2",
-                  PV_GIS_TWO_AXIS)
+    download.file(
+        "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&trackingtype=2",
+        PV_GIS_TWO_AXIS
+    )
 
 }
 
@@ -78,31 +95,45 @@ d.gen.sel <- d.generation %>%
     ungroup()
 
 d.gen.sel.ren <- d.gen.sel %>%
-    filter(source %in% c("Wind Onshore",
-                         "Solar",
-                         "Hydro Run-of-river and poundage",
-                         "Nuclear",
-                         "Wind Offshore")) %>%
+    filter(
+        source %in% c(
+            "Wind Onshore",
+            "Solar",
+            "Hydro Run-of-river and poundage",
+            "Nuclear",
+            "Wind Offshore"
+        )
+    ) %>%
     group_by(DateTime, country) %>%
     summarize(generation = sum(value, na.rm = TRUE))
 
 d.gen.sel.ren.wo.nuclear <- d.gen.sel %>%
-    filter(source %in% c("Wind Onshore",
-                         "Solar",
-                         "Hydro Run-of-river and poundage",
-                         "Wind Offshore")) %>%
+    filter(
+        source %in% c(
+            "Wind Onshore",
+            "Solar",
+            "Hydro Run-of-river and poundage",
+            "Wind Offshore"
+        )
+    ) %>%
     group_by(DateTime, country) %>%
     summarize(generation = sum(value, na.rm = TRUE))
 
 d.residual <- d.gen.sel.ren %>%
     dplyr::select(DateTime, country, generation)  %>%
-    full_join(d.load %>% dplyr::select(DateTime, country, value), by = c("DateTime" = "DateTime", "country" = "country")) %>%
+    full_join(
+        d.load %>% dplyr::select(DateTime, country, value),
+        by = c("DateTime" = "DateTime", "country" = "country")
+    ) %>%
     mutate(residual = value - generation)
 
 d.residual.wo.nuclear <- d.gen.sel.ren.wo.nuclear %>%
     mutate(value = ifelse(is.na(generation), 0, generation)) %>%
     dplyr::select(DateTime, country, generation)  %>%
-    full_join(d.load %>% dplyr::select(DateTime, country, value), by = c("DateTime" = "DateTime", "country" = "country")) %>%
+    full_join(
+        d.load %>% dplyr::select(DateTime, country, value),
+        by = c("DateTime" = "DateTime", "country" = "country")
+    ) %>%
     mutate(residual = value - generation)
 
 d.prices.filtered <- d.prices %>%
@@ -114,8 +145,9 @@ d.prices.filtered <- d.prices %>%
     dplyr::select(DateTime, year, price, country)
 
 ### CAP FACT AVERAGE ###
-ninja_pv <- read_csv("data/ninja/ninja_pv_europe_v1.1_sarah.csv") %>%
-    gather(country, value, -time) %>%
+ninja_pv <-
+    read_csv(glue("{NINJA_DIR}ninja_pv_europe_v1.1_sarah.csv")) %>%
+    gather(country, value,-time) %>%
     filter(country %in% COUNTRIES) %>%
     group_by(year(time), country) %>%
     mutate(t = 1:n()) %>%
@@ -123,8 +155,11 @@ ninja_pv <- read_csv("data/ninja/ninja_pv_europe_v1.1_sarah.csv") %>%
     group_by(country, t) %>%
     summarize(pv = mean(value))
 
-ninja_wind <- read_csv("data/ninja/ninja_wind_europe_v1.1_future_nearterm_national.csv") %>%
-    gather(country, value, -time) %>%
+ninja_wind <-
+    read_csv(glue(
+        "{NINJA_DIR}ninja_wind_europe_v1.1_future_nearterm_national.csv"
+    )) %>%
+    gather(country, value,-time) %>%
     filter(country %in% COUNTRIES) %>%
     group_by(year(time), country) %>%
     mutate(t = 1:n()) %>%
@@ -140,50 +175,52 @@ d.prices.filtered <- d.prices.filtered %>%
 max_date <- max(d.prices.filtered$DateTime)
 
 ########## different pv system values for austria
-list.csv.files <- c(PV_GIS_OPT,
-                    PV_GIS_EAST,
-                    PV_GIS_WEST,
-                    PV_GIS_VERTICAL_EAST,
-                    PV_GIS_VERTICAL_WEST,
-                    PV_GIS_VERTICAL_NORTH,
-                    PV_GIS_VERTICAL_SOUTH,
-                    PV_GIS_TWO_AXIS)
+list.csv.files <- c(
+    PV_GIS_OPT,
+    PV_GIS_EAST,
+    PV_GIS_WEST,
+    PV_GIS_VERTICAL_EAST,
+    PV_GIS_VERTICAL_WEST,
+    PV_GIS_VERTICAL_NORTH,
+    PV_GIS_VERTICAL_SOUTH,
+    PV_GIS_TWO_AXIS
+)
 
-d.pv.gis <- read_csv(list.csv.files, skip=19, id="type") %>%
-    mutate(time=ymd_hm(time)) %>%
-    mutate(type = str_remove(type, "pv-gis")) %>%
-    mutate(type = str_remove(type, "\\.csv")) %>%
-    mutate(type = str_remove(type, "data")) %>%
-    mutate(type = str_remove(type, "ninja")) %>%
-    mutate(type = str_remove_all(type, "\\\\")) %>%
+d.pv.gis <- read_csv(list.csv.files, skip = 19, id = "type") %>%
+    mutate(time = ymd_hm(time)) %>%
+    mutate(type = str_remove_all(type, "pv-gis|\\.csv|data|ninja|/")) %>%
+    mutate(type = str_replace_all(type, "-", ".")) %>%
     na.omit()
 
 d.pv.gis.2018 = d.pv.gis %>%
     filter(year(time) == 2018) %>%
     dplyr::select(time, type, P) %>%
     spread(type, P) %>%
-    mutate(vertical.north.south = 0.5 * `//-vertical-north` + 0.5 * `//-vertical-south`) %>%
-    mutate(vertical.east.west = 0.5 * `//-vertical-east` + 0.5 * `//-vertical-west`) %>%
-    mutate(angle.east.west = 0.5 * `//-38-east` + 0.5 * `//-38-west`) %>%
-    mutate(vertical.south = `//-vertical-south`) %>%
-    dplyr::select(time,
-                  vertical.north.south,
-                  vertical.east.west,
-                  angle.east.west,
-                  vertical.south,
-                  opt.opt=`//-opt-opt`,
-                  two.axis=`//-two-axis`) %>%
-    gather(type, P, -time) %>%
+    mutate(vertical.north.south = 0.5 * `.vertical.north` + 0.5 * `.vertical.south`) %>%
+    mutate(vertical.east.west = 0.5 * `.vertical.east` + 0.5 * `.vertical.west`) %>%
+    mutate(angle.east.west = 0.5 * `.38.east` + 0.5 * `.38.west`) %>%
+    dplyr::select(
+        time,
+        vertical.north.south,
+        vertical.east.west,
+        angle.east.west,
+        vertical.south = .vertical.south,
+        opt.opt = `.opt.opt`,
+        two.axis = `.two.axis`
+    ) %>%
+    gather(type, P,-time) %>%
     group_by(type) %>%
-    mutate(t=1:n()) %>%
+    mutate(t = 1:n()) %>%
     ungroup()
 
 
-d.join.prices.pv = full_join(d.prices.filtered %>%
-              filter(country == "AT"),
-          d.pv.gis.2018,
-          by = c("t" = "t"),
-          relationship = "many-to-many") %>%
+d.join.prices.pv = full_join(
+    d.prices.filtered %>%
+        filter(country == "AT"),
+    d.pv.gis.2018,
+    by = c("t" = "t"),
+    relationship = "many-to-many"
+) %>%
     mutate(value = P / 1000 * price) %>%
     mutate(month = month(DateTime)) %>%
     mutate(year = year(DateTime)) %>%
@@ -198,4 +235,5 @@ d.join.prices.pv = full_join(d.prices.filtered %>%
     mutate(rollvalue = value / 1000) %>%
     ungroup() %>%
     #na.omit() %>%
-    filter(year < max(year) | (year == max(year) & month < month(max_date)))
+    filter(year < max(year) |
+               (year == max(year) & month < month(max_date)))

--- a/calc/setup-value-renewables.R
+++ b/calc/setup-value-renewables.R
@@ -1,8 +1,6 @@
-library(tidyverse)
 rm(list = ls())
-#source("load/entsoe/_shared.r")
 source("_shared.r")
-source("calc/prediction-gas-consumption/_functions.r")
+loadPackages('tidyverse')
 
 download_ninja = TRUE
 download_pv_gis = TRUE
@@ -68,7 +66,7 @@ COUNTRIES <- c("AT", "ES", "DE", "FR")
 d.generation = loadFromStorage(id = "electricity-generation-hourly")
 
 d.prices = loadFromStorage(id = "electricity-price-entsoe-hourly") %>%
-    mutate(country = substr(AreaName, 1,2))
+    mutate(country = ifelse(country == "DE_LU", "DE", country))
 
 d.load = loadFromStorage(id = "electricity-load-hourly-res") %>%
     filter(country %in% COUNTRIES)
@@ -113,7 +111,7 @@ d.prices.filtered <- d.prices %>%
     filter(year > 2018) %>%
     filter(country %in% COUNTRIES) %>%
     arrange(DateTime) %>%
-    dplyr::select(DateTime, year, mean, country)
+    dplyr::select(DateTime, year, price, country)
 
 ### CAP FACT AVERAGE ###
 ninja_pv <- read_csv("data/ninja/ninja_pv_europe_v1.1_sarah.csv") %>%
@@ -186,7 +184,7 @@ d.join.prices.pv = full_join(d.prices.filtered %>%
           d.pv.gis.2018,
           by = c("t" = "t"),
           relationship = "many-to-many") %>%
-    mutate(value = P / 1000 * mean) %>%
+    mutate(value = P / 1000 * price) %>%
     mutate(month = month(DateTime)) %>%
     mutate(year = year(DateTime)) %>%
     filter(year > 2018) %>%
@@ -201,12 +199,3 @@ d.join.prices.pv = full_join(d.prices.filtered %>%
     ungroup() %>%
     #na.omit() %>%
     filter(year < max(year) | (year == max(year) & month < month(max_date)))
-
-
-
-
-
-
-
-
-

--- a/calc/setup-value-renewables.R
+++ b/calc/setup-value-renewables.R
@@ -14,6 +14,17 @@ PV_GIS_VERTICAL_NORTH = "data/ninja/pv-gis-vertical-north.csv"
 PV_GIS_VERTICAL_SOUTH = "data/ninja/pv-gis-vertical-south.csv"
 PV_GIS_TWO_AXIS = "data/ninja/pv-gis-two-axis.csv"
 
+list.csv.files <- c(
+    PV_GIS_OPT,
+    PV_GIS_EAST,
+    PV_GIS_WEST,
+    PV_GIS_VERTICAL_EAST,
+    PV_GIS_VERTICAL_WEST,
+    PV_GIS_VERTICAL_NORTH,
+    PV_GIS_VERTICAL_SOUTH,
+    PV_GIS_TWO_AXIS
+)
+
 download_ninja = TRUE
 download_pv_gis = TRUE
 
@@ -75,6 +86,17 @@ if (download_pv_gis) {
         "https://re.jrc.ec.europa.eu/api/v5_2/seriescalc?pvcalculation=1&peakpower=1&loss=0.1&lat=48.32&lon=16.54&outputformat=csv&outputformat=1&trackingtype=2",
         PV_GIS_TWO_AXIS
     )
+
+    # replace \r in PV_GIS files
+    if(Sys.info()["sysname"] == "windows") {
+        for( f in list.csv.files){
+
+            x <- readLines(f)
+            y <- gsub( "\r", "", x)
+            cat(y, file=f, sep="\n")
+
+        }
+    }
 
 }
 
@@ -174,22 +196,12 @@ d.prices.filtered <- d.prices.filtered %>%
 max_date <- max(d.prices.filtered$DateTime)
 
 ########## different pv system values for austria
-list.csv.files <- c(
-    PV_GIS_OPT,
-    PV_GIS_EAST,
-    PV_GIS_WEST,
-    PV_GIS_VERTICAL_EAST,
-    PV_GIS_VERTICAL_WEST,
-    PV_GIS_VERTICAL_NORTH,
-    PV_GIS_VERTICAL_SOUTH,
-    PV_GIS_TWO_AXIS
-)
-
-d.pv.gis <- read_csv(list.csv.files, skip = 19, id = "type") %>%
+d.pv.gis = read_csv(list.csv.files, skip = 10, id = "type") %>%
     mutate(time = ymd_hm(time)) %>%
     mutate(type = str_remove_all(type, "pv-gis|\\.csv|data|ninja|/")) %>%
     mutate(type = str_replace_all(type, "-", ".")) %>%
-    na.omit()
+    na.omit() %>%
+    mutate(P = as.numeric(P))
 
 d.pv.gis.2018 = d.pv.gis %>%
     filter(year(time) == 2018) %>%

--- a/export/analysis/_run.r
+++ b/export/analysis/_run.r
@@ -7,6 +7,7 @@ loadPackages(rmarkdown, knitr)
 
 # - CONF -----------------------------------------------------------------------
 args = commandArgs(trailingOnly=TRUE)
+# args = "value-renewables" # "gas-storage"
 if (length(args) == 0) {
     stop("Specify the markdown to render as arg", call. = FALSE)
 } else if (length(args) == 1) {
@@ -26,6 +27,13 @@ e = rlang::env()
 
 e$output.file = output.file
 e$output.folder = normalizePath(file.path(getwd(), output.folder))
+
+
+# print(list(
+#     output.folder = normalizePath(file.path(getwd(), output.folder)),
+#     output.file = output.file,
+#     wd = getwd()
+# ))
 
 render(
     input = input.file,

--- a/load/entsoe/generation-hourly-res.r
+++ b/load/entsoe/generation-hourly-res.r
@@ -1,0 +1,40 @@
+# - INIT -----------------------------------------------------------------------
+rm(list = ls())
+source("load/entsoe/_shared.r")
+# loadPackages()
+
+
+# - LOAD/PREP ------------------------------------------------------------------
+update.time = now()
+
+d.base = loadEntsoeComb(
+    type = "generation",
+    month.start = "2014-12",
+    month.end = month.end
+)
+
+d.base.f = d.base[AreaTypeCode == "CTY"]
+d.base.f[, hour := floor_date(DateTime, unit = "hours")]
+
+
+d.agg = d.base.f[, .(
+    value = mean(ActualGenerationOutput, na.rm = TRUE),
+    cons = mean(ActualConsumption, na.rm = TRUE)
+), by = .(
+    country = MapCode,
+    source = ProductionType,
+    DateTime = hour
+)][order(DateTime)]
+
+
+# - STORE ----------------------------------------------------------------------
+saveToStorages(
+    d.agg,
+    list(
+        id = "electricity-generation-hourly",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)
+

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -7,11 +7,10 @@ source("load/entsoe/_shared.r")
 # - LOAD/PREP ------------------------------------------------------------------
 update.time = now()
 
-d.base = loadEntsoeComb(
-    # type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
-    type = "generation", month.start = "2014-12", month.end = month.end
-
-)
+d.base = loadEntsoeComb(# type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
+    type = "generation",
+    month.start = "2014-12",
+    month.end = month.end)
 
 d.base.f = d.base[AreaTypeCode == "CTY"]
 d.base.f[,
@@ -22,39 +21,39 @@ d.base.f[,
 d.agg.hours = d.base.f[, .(
     value = mean(ActualGenerationOutput, na.rm = TRUE),
     cons = mean(ActualConsumption, na.rm = TRUE)
-), by = .(
-    country = MapCode,
-    source = ProductionType,
-    DateTime = hour
-)][order(DateTime)]
+), by = .(country = MapCode,
+          source = ProductionType,
+          DateTime = hour)][order(DateTime)]
 
 # - AGG -----------------------------------------------------------------------
-d.agg = d.agg.hours[, .(
-    value = sum(value) / 10^6,
-    cons = sum(cons) / 10^6
-), by = .(
-    country = country,
-    date = as.Date(DateTime),
-    source = source
-)][order(date)]
+d.agg = d.agg.hours[, .(value = sum(value) / 10 ^ 6,
+                        cons = sum(cons) / 10 ^ 6), by = .(country = country,
+                                                           date = as.Date(DateTime),
+                                                           source = source)][order(date)]
 
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 2)
 
 # - STORE ----------------------------------------------------------------------
-saveToStorages(d.agg.hours, list(
-    id = "electricity-generation-hourly",
-    source = "entsoe",
-    format = "csv",
-    update.time = update.time
-))
+saveToStorages(
+    d.agg.hours,
+    list(
+        id = "electricity-generation-hourly",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)
 
-saveToStorages(d.agg, list(
-    id = "electricity-generation",
-    source = "entsoe",
-    format = "csv",
-    update.time = update.time
-))
+saveToStorages(
+    d.agg,
+    list(
+        id = "electricity-generation",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)
 
 
 nameOthers = "others"
@@ -62,29 +61,31 @@ nameOthers = "others"
 # - GROUP 1
 addGroupCol(d.agg, c.sourceGroups1, nameOthers = nameOthers)
 # Agg
-d.agg.group = d.agg[, .(
-    value = sum(value),
-    cons = sum(cons)
-), by = .(country, date, source.group)]
+d.agg.group = d.agg[, .(value = sum(value),
+                        cons = sum(cons)), by = .(country, date, source.group)]
 # Store
-saveToStorages(d.agg.group, list(
-    id = "electricity-generation-g1",
-    source = "entsoe",
-    format = "csv",
-    update.time = update.time
-))
+saveToStorages(
+    d.agg.group,
+    list(
+        id = "electricity-generation-g1",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)
 
 # - GROUP 2
 addGroupCol(d.agg, c.sourceGroups2, nameOthers = nameOthers)
 # Agg
-d.agg.group = d.agg[, .(
-    value = sum(value),
-    cons = sum(cons)
-), by = .(country, date, source.group)]
+d.agg.group = d.agg[, .(value = sum(value),
+                        cons = sum(cons)), by = .(country, date, source.group)]
 # Store
-saveToStorages(d.agg.group, list(
-    id = "electricity-generation-g2",
-    source = "entsoe",
-    format = "csv",
-    update.time = update.time
-))
+saveToStorages(
+    d.agg.group,
+    list(
+        id = "electricity-generation-g2",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -6,53 +6,40 @@ source("load/entsoe/_shared.r")
 
 # - LOAD/PREP ------------------------------------------------------------------
 update.time = now()
+d.base = loadEntsoeComb(
+    # type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
+    type = "generation", month.start = "2014-12", month.end = month.end
+)
 
-d.base = loadEntsoeComb(# type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
-    type = "generation",
-    month.start = "2014-12",
-    month.end = month.end)
+# unique(d.base$ProductionType)
 
 d.base.f = d.base[AreaTypeCode == "CTY"]
-d.base.f[,
-         hour := floor_date(DateTime, unit = "hours")]
+d.base.f[, factor := resToFactor[ResolutionCode]]
+# d.base.f[, .(sum = sum(ActualGenerationOutput)), by=.(ProductionType)][order(sum)]
+# unique(d.base.f[,. (ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
 
-
-d.agg.hours = d.base.f[, .(
-    value = mean(ActualGenerationOutput, na.rm = TRUE),
-    cons = mean(ActualConsumption, na.rm = TRUE)
-), by = .(country = MapCode,
-          source = ProductionType,
-          DateTime = hour)][order(DateTime)]
 
 # - AGG -----------------------------------------------------------------------
-d.agg = d.agg.hours[, .(value = sum(value) / 10 ^ 6,
-                        cons = sum(cons) / 10 ^ 6), by = .(country = country,
-                                                           date = as.Date(DateTime),
-                                                           source = source)][order(date)]
+d.agg = d.base.f[, .(
+    value = sum(ActualGenerationOutput*factor, na.rm = TRUE)/10^6,
+    cons = sum(ActualConsumption*factor, na.rm = TRUE)/10^6
+), by = .(
+    country = MapCode,
+    date = as.Date(DateTime),
+    source = ProductionType
+)][order(date)]
 
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 2)
 
-# - STORE ----------------------------------------------------------------------
-saveToStorages(
-    d.agg.hours,
-    list(
-        id = "electricity-generation-hourly",
-        source = "entsoe",
-        format = "csv",
-        update.time = update.time
-    )
-)
 
-saveToStorages(
-    d.agg,
-    list(
-        id = "electricity-generation",
-        source = "entsoe",
-        format = "csv",
-        update.time = update.time
-    )
-)
+# - STORE ----------------------------------------------------------------------
+saveToStorages(d.agg, list(
+    id = "electricity-generation",
+    source = "entsoe",
+    format = "csv",
+    update.time = update.time
+))
 
 
 nameOthers = "others"
@@ -60,31 +47,29 @@ nameOthers = "others"
 # - GROUP 1
 addGroupCol(d.agg, c.sourceGroups1, nameOthers = nameOthers)
 # Agg
-d.agg.group = d.agg[, .(value = sum(value),
-                        cons = sum(cons)), by = .(country, date, source.group)]
+d.agg.group = d.agg[, .(
+    value = sum(value),
+    cons = sum(cons)
+), by = .(country, date, source.group)]
 # Store
-saveToStorages(
-    d.agg.group,
-    list(
-        id = "electricity-generation-g1",
-        source = "entsoe",
-        format = "csv",
-        update.time = update.time
-    )
-)
+saveToStorages(d.agg.group, list(
+    id = "electricity-generation-g1",
+    source = "entsoe",
+    format = "csv",
+    update.time = update.time
+))
 
 # - GROUP 2
 addGroupCol(d.agg, c.sourceGroups2, nameOthers = nameOthers)
 # Agg
-d.agg.group = d.agg[, .(value = sum(value),
-                        cons = sum(cons)), by = .(country, date, source.group)]
+d.agg.group = d.agg[, .(
+    value = sum(value),
+    cons = sum(cons)
+), by = .(country, date, source.group)]
 # Store
-saveToStorages(
-    d.agg.group,
-    list(
-        id = "electricity-generation-g2",
-        source = "entsoe",
-        format = "csv",
-        update.time = update.time
-    )
-)
+saveToStorages(d.agg.group, list(
+    id = "electricity-generation-g2",
+    source = "entsoe",
+    format = "csv",
+    update.time = update.time
+))

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -3,6 +3,8 @@ rm(list = ls())
 source("load/entsoe/_shared.r")
 # loadPackages()
 
+library(lubridate)
+
 
 # - LOAD/PREP ------------------------------------------------------------------
 update.time = now()
@@ -43,10 +45,8 @@ d.agg.hours = d.base.f[, .(
 ), by = .(
     country = MapCode,
     source = ProductionType,
-    DateTime = hour
-
+    DateTime = ymd_hms(hour)
 )][order(DateTime)]
-
 
 # - STORE ----------------------------------------------------------------------
 saveToStorages(d.agg, list(
@@ -62,8 +62,6 @@ saveToStorages(d.agg.hours, list(
     format = "csv",
     update.time = update.time
 ))
-
-
 
 nameOthers = "others"
 

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -8,9 +8,17 @@ library(lubridate)
 
 # - LOAD/PREP ------------------------------------------------------------------
 update.time = now()
+
 d.base = loadEntsoeComb(
     # type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
-    type = "generation", month.start = "2014-12", month.end = month.end
+    type = "generation", month.start = "2024-03", month.end = month.end
+
+)
+
+d.base = loadEntsoeComb(
+    # type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
+    type = "generation", month.start = "2014-12", month.end = month.end, check.updates = FALSE
+
 )
 
 # unique(d.base$ProductionType)

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -10,7 +10,7 @@ library(lubridate)
 update.time = now()
 d.base = loadEntsoeComb(
     # type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
-    type = "generation", month.start = "2014-12", month.end = month.end, check.updates = FALSE
+    type = "generation", month.start = "2014-12", month.end = month.end
 )
 
 # unique(d.base$ProductionType)

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -41,6 +41,18 @@ saveToStorages(d.agg, list(
     update.time = update.time
 ))
 
+d.agg.hours %>%
+    filter(country == "AT") %>%
+    filter(source == "Solar") %>%
+    filter(year(DateTime) == 2024 & month(DateTime) == 4 & day(DateTime) == 13) %>%
+    filter(value>0) %>%
+    summarize(s=sum(value) /10^3)
+
+d.agg.hours %>%
+    filter(country == "AT") %>%
+    filter(source == "Solar") %>%
+    filter(year(DateTime) == 2024 & month(DateTime) == 4 & day(DateTime) == 13) %>%
+    filter(value>0)
 
 nameOthers = "others"
 

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -3,8 +3,6 @@ rm(list = ls())
 source("load/entsoe/_shared.r")
 # loadPackages()
 
-library(lubridate)
-
 
 # - LOAD/PREP ------------------------------------------------------------------
 update.time = now()
@@ -15,18 +13,11 @@ d.base = loadEntsoeComb(
 
 )
 
-# unique(d.base$ProductionType)
-
 d.base.f = d.base[AreaTypeCode == "CTY"]
 d.base.f[,
          hour := floor_date(DateTime, unit = "hours")]
 d.base.f[,
          factor := resToFactor[ResolutionCode]]
-
-
-# d.base.f[, .(sum = sum(ActualGenerationOutput)), by=.(ProductionType)][order(sum)]
-# unique(d.base.f[,. (ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
-
 
 d.agg.hours = d.base.f[, .(
     value = mean(ActualGenerationOutput, na.rm = TRUE),

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -11,13 +11,7 @@ update.time = now()
 
 d.base = loadEntsoeComb(
     # type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
-    type = "generation", month.start = "2024-03", month.end = month.end
-
-)
-
-d.base = loadEntsoeComb(
-    # type = "generation", month.start = "2022-07", month.end = "2022-07", check.updates = FALSE
-    type = "generation", month.start = "2014-12", month.end = month.end, check.updates = FALSE
+    type = "generation", month.start = "2014-12", month.end = month.end
 
 )
 

--- a/load/entsoe/generation.r
+++ b/load/entsoe/generation.r
@@ -15,8 +15,7 @@ d.base = loadEntsoeComb(# type = "generation", month.start = "2022-07", month.en
 d.base.f = d.base[AreaTypeCode == "CTY"]
 d.base.f[,
          hour := floor_date(DateTime, unit = "hours")]
-d.base.f[,
-         factor := resToFactor[ResolutionCode]]
+
 
 d.agg.hours = d.base.f[, .(
     value = mean(ActualGenerationOutput, na.rm = TRUE),

--- a/load/entsoe/load-hourly-res.r
+++ b/load/entsoe/load-hourly-res.r
@@ -1,0 +1,29 @@
+# - INIT -----------------------------------------------------------------------
+rm(list = ls())
+source("load/entsoe/_shared.r")
+# loadPackages()
+
+
+# - DOIT -----------------------------------------------------------------------
+update.time = now()
+d.base = loadEntsoeComb(
+    type = "load",
+    month.start = "2014-12",
+    month.end = month.end
+)
+
+d.base.f = d.base[AreaTypeCode == "CTY"]
+d.base.f[, hour := (floor_date(DateTime, unit = "hours"))]
+
+d.agg = d.base.f[, .(
+    value = mean(TotalLoadValue, na.rm = TRUE)
+), by = .(country = MapCode, DateTime = hour)]
+
+
+# - STORE ----------------------------------------------------------------------
+saveToStorages(d.agg, list(
+    id = "electricity-load-hourly-res",
+    source = "entsoe",
+    format = "csv",
+    update.time = update.time
+))

--- a/load/entsoe/load.r
+++ b/load/entsoe/load.r
@@ -11,15 +11,9 @@ d.base = loadEntsoeComb(
     # type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE
 )
 
-# d.t = unique(d.base[, .(ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
-# d.t = unique(d.base[AreaTypeCode == "CTY", .(ResolutionCode, AreaCode, AreaName, MapCode)])
-
 d.base.f = d.base[AreaTypeCode == "CTY"]
 
-# sort(unique(d.base.f$ResolutionCode))
-
 d.base.f[, factor := resToFactor[ResolutionCode]]
-#d.base.f[, value := factor * TotalLoadValue]
 
 d.base.f[,  hour := (floor_date(DateTime, unit = "hours"))]
 

--- a/load/entsoe/load.r
+++ b/load/entsoe/load.r
@@ -26,6 +26,13 @@ d.agg = d.base.f[, .(
     value = sum(value) / 10^6
 ), by = .(country = MapCode, date = as.Date(DateTime))][order(date)]
 
+d.agg.hours = d.base.f[, .(
+    value = sum(value) / 10^6
+), by = .(
+    country = MapCode,
+    DateTime = ymd_hms(hour)
+)]
+
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 2)
 
@@ -33,6 +40,13 @@ d.agg = removeLastDays(d.agg, 2)
 # - STORE ----------------------------------------------------------------------
 saveToStorages(d.agg, list(
     id = "electricity-load",
+    source = "entsoe",
+    format = "csv",
+    update.time = update.time
+))
+
+saveToStorages(d.agg.hours, list(
+    id = "electricity-load-hourly-res",
     source = "entsoe",
     format = "csv",
     update.time = update.time

--- a/load/entsoe/load.r
+++ b/load/entsoe/load.r
@@ -13,16 +13,13 @@ d.base = loadEntsoeComb(type = "load",
 
 d.base.f = d.base[AreaTypeCode == "CTY"]
 
-d.base.f[, factor := resToFactor[ResolutionCode]]
-
 d.base.f[,  hour := (floor_date(DateTime, unit = "hours"))]
 
-d.agg.hours = d.base.f[, .(value = mean(TotalLoadValue / factor, na.rm = TRUE)), by = .(country = MapCode,
+d.agg.hours = d.base.f[, .(value = mean(TotalLoadValue, na.rm = TRUE)), by = .(country = MapCode,
                                                                                DateTime = hour)]
 
 # Filter, Aggregate
 d.agg = d.agg.hours[, .(value = sum(value) / 10 ^ 6), by = .(country = country, date = as.Date(DateTime))][order(date)]
-
 
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 2)

--- a/load/entsoe/load.r
+++ b/load/entsoe/load.r
@@ -6,42 +6,34 @@ source("load/entsoe/_shared.r")
 
 # - DOIT -----------------------------------------------------------------------
 update.time = now()
-d.base = loadEntsoeComb(type = "load",
-                        month.start = "2014-12",
-                        month.end = month.end)
-# type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE)
+d.base = loadEntsoeComb(
+    type = "load", month.start = "2014-12", month.end = month.end
+    # type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE
+)
+
+# d.t = unique(d.base[, .(ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
+# d.t = unique(d.base[AreaTypeCode == "CTY", .(ResolutionCode, AreaCode, AreaName, MapCode)])
 
 d.base.f = d.base[AreaTypeCode == "CTY"]
 
-d.base.f[,  hour := (floor_date(DateTime, unit = "hours"))]
+# sort(unique(d.base.f$ResolutionCode))
 
-d.agg.hours = d.base.f[, .(value = mean(TotalLoadValue, na.rm = TRUE)), by = .(country = MapCode,
-                                                                               DateTime = hour)]
+d.base.f[, factor := resToFactor[ResolutionCode]]
+d.base.f[, value := factor * TotalLoadValue]
 
 # Filter, Aggregate
-d.agg = d.agg.hours[, .(value = sum(value) / 10 ^ 6), by = .(country = country, date = as.Date(DateTime))][order(date)]
+d.agg = d.base.f[, .(
+    value = sum(value) / 10^6
+), by = .(country = MapCode, date = as.Date(DateTime))][order(date)]
 
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 2)
 
 
 # - STORE ----------------------------------------------------------------------
-saveToStorages(
-    d.agg,
-    list(
-        id = "electricity-load",
-        source = "entsoe",
-        format = "csv",
-        update.time = update.time
-    )
-)
-
-saveToStorages(
-    d.agg.hours,
-    list(
-        id = "electricity-load-hourly-res",
-        source = "entsoe",
-        format = "csv",
-        update.time = update.time
-    )
-)
+saveToStorages(d.agg, list(
+    id = "electricity-load",
+    source = "entsoe",
+    format = "csv",
+    update.time = update.time
+))

--- a/load/entsoe/load.r
+++ b/load/entsoe/load.r
@@ -6,10 +6,10 @@ source("load/entsoe/_shared.r")
 
 # - DOIT -----------------------------------------------------------------------
 update.time = now()
-d.base = loadEntsoeComb(
-    type = "load", month.start = "2014-12", month.end = month.end
-    # type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE
-)
+d.base = loadEntsoeComb(type = "load",
+                        month.start = "2014-12",
+                        month.end = month.end)
+# type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE)
 
 d.base.f = d.base[AreaTypeCode == "CTY"]
 
@@ -17,17 +17,11 @@ d.base.f[, factor := resToFactor[ResolutionCode]]
 
 d.base.f[,  hour := (floor_date(DateTime, unit = "hours"))]
 
-d.agg.hours = d.base.f[, .(
-    value = mean(value / factor, na.rm = TRUE)
-), by = .(
-    country = MapCode,
-    DateTime = hour
-)]
+d.agg.hours = d.base.f[, .(value = mean(TotalLoadValue / factor, na.rm = TRUE)), by = .(country = MapCode,
+                                                                               DateTime = hour)]
 
 # Filter, Aggregate
-d.agg = d.agg.hours[, .(
-    value = sum(value) / 10^6
-), by = .(country = country, date = as.Date(DateTime))][order(date)]
+d.agg = d.agg.hours[, .(value = sum(value) / 10 ^ 6), by = .(country = country, date = as.Date(DateTime))][order(date)]
 
 
 # Delete last (most probably incomplete) obs
@@ -35,16 +29,22 @@ d.agg = removeLastDays(d.agg, 2)
 
 
 # - STORE ----------------------------------------------------------------------
-saveToStorages(d.agg, list(
-    id = "electricity-load",
-    source = "entsoe",
-    format = "csv",
-    update.time = update.time
-))
+saveToStorages(
+    d.agg,
+    list(
+        id = "electricity-load",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)
 
-saveToStorages(d.agg.hours, list(
-    id = "electricity-load-hourly-res",
-    source = "entsoe",
-    format = "csv",
-    update.time = update.time
-))
+saveToStorages(
+    d.agg.hours,
+    list(
+        id = "electricity-load-hourly-res",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)

--- a/load/entsoe/price-hourly-res.r
+++ b/load/entsoe/price-hourly-res.r
@@ -1,0 +1,37 @@
+# - INIT -----------------------------------------------------------------------
+rm(list = ls())
+source("load/entsoe/_shared.r")
+# loadPackages()
+
+
+# - DOIT -----------------------------------------------------------------------
+update.time = now()
+d.base = loadEntsoeComb(
+    type = "dayAheadPrices",
+    month.start = month.start,
+    month.end = month.end
+)
+
+d.base.f = d.base[ResolutionCode == "PT60M"]
+d.base.f = d.base.f[, hour := floor_date(DateTime, unit = "hours")]
+
+d.agg = d.base.f[, .(
+    price = mean(Price)
+), by = .(
+    country = MapCode,
+    DateTime = hour,
+    ResolutionCode
+)][order(country, DateTime)]
+
+
+# # - STORE --------------------------------------------------------------------
+saveToStorages(
+    d.agg,
+    list(
+        id = "electricity-price-entsoe-hourly",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)
+

--- a/load/entsoe/price.r
+++ b/load/entsoe/price.r
@@ -13,16 +13,10 @@ d.base = loadEntsoeComb(
     # type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE
 )
 
-# unique(d.base[, .(ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
-# d.t = unique(d.base[AreaTypeCode == "CTY", .(ResolutionCode, AreaCode, AreaName, MapCode)])
-
-#d.base.f = d.base[AreaCode == "10YAT-APG------L" & ResolutionCode == "PT60M"]
 d.base.f = d.base[,
-                  hour := cut(DateTime, breaks = "hour")]
+                  hour := floor_date(DateTime, unit = "hours")]
 
-# unique(d.base.f[, .(ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
-
-d.agg = d.base.f[, .(
+d.agg = d.base.f[MapCode == "AT", .(
     mean = mean(Price),
     max = max(Price),
     min = min(Price)
@@ -31,22 +25,12 @@ d.agg = d.base.f[, .(
 )]
 
 d.agg.hours = d.base.f[, .(
-    Price = mean(Price)
+    price = mean(Price)
 ), by = .(
-    AreaName,
-    DateTime = ymd_hms(hour),
+    country = MapCode,
+    DateTime = hour,
     ResolutionCode
 )]
-
-# sort(unique(d.base.f$ResolutionCode))
-
-# d.base.f[, factor := resToFactor[ResolutionCode]]
-# d.base.f[, value := factor*TotalLoadValue]
-
-# # Filter, Aggregate
-# d.agg = d.base.f[, .(
-#     value = sum(value)/10^3
-# ), by = .(country = MapCode, date = as.Date(DateTime))][order(date)]
 
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 1)

--- a/load/entsoe/price.r
+++ b/load/entsoe/price.r
@@ -31,9 +31,7 @@ d.agg = d.base.f[, .(
 )]
 
 d.agg.hours = d.base.f[, .(
-    mean = mean(Price),
-    max = max(Price),
-    min = min(Price)
+    Price = mean(Price)
 ), by = .(
     AreaName,
     DateTime = ymd_hms(hour),

--- a/load/entsoe/price.r
+++ b/load/entsoe/price.r
@@ -6,47 +6,45 @@ source("load/entsoe/_shared.r")
 
 # - DOIT -----------------------------------------------------------------------
 update.time = now()
-d.base = loadEntsoeComb(
-    #type = "dayAheadPrices", month.start = month.start, month.end = month.end
-    type = "dayAheadPrices", month.start = month.start, month.end = month.end
+d.base = loadEntsoeComb(#type = "dayAheadPrices", month.start = month.start, month.end = month.end
+    type = "dayAheadPrices",
+    month.start = month.start,
+    month.end = month.end)
 
-    # type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE
-)
+# type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE)
 
 d.base.f = d.base[,
                   hour := floor_date(DateTime, unit = "hours")]
 
-d.agg = d.base.f[MapCode == "AT", .(
-    mean = mean(Price),
-    max = max(Price),
-    min = min(Price)
-), by = .(
-    date = as.Date(DateTime)
-)]
+d.agg = d.base.f[MapCode == "AT", .(mean = mean(Price),
+                                    max = max(Price),
+                                    min = min(Price)), by = .(date = as.Date(DateTime))]
 
-d.agg.hours = d.base.f[, .(
-    price = mean(Price)
-), by = .(
-    country = MapCode,
-    DateTime = hour,
-    ResolutionCode
-)]
+d.agg.hours = d.base.f[, .(price = mean(Price)), by = .(country = MapCode,
+                                                        DateTime = hour,
+                                                        ResolutionCode)]
 
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 1)
 
 
 # # - STORE --------------------------------------------------------------------
-saveToStorages(d.agg, list(
-    id = "electricity-price-entsoe",
-    source = "entsoe",
-    format = "csv",
-    update.time = update.time
-))
+saveToStorages(
+    d.agg,
+    list(
+        id = "electricity-price-entsoe",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)
 
-saveToStorages(d.agg.hours, list(
-    id = "electricity-price-entsoe-hourly",
-    source = "entsoe",
-    format = "csv",
-    update.time = update.time
-))
+saveToStorages(
+    d.agg.hours,
+    list(
+        id = "electricity-price-entsoe-hourly",
+        source = "entsoe",
+        format = "csv",
+        update.time = update.time
+    )
+)

--- a/load/entsoe/price.r
+++ b/load/entsoe/price.r
@@ -13,16 +13,18 @@ d.base = loadEntsoeComb(#type = "dayAheadPrices", month.start = month.start, mon
 
 # type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE)
 
-d.base.f = d.base[,
+d.base.f = d.base[AreaCode == "10YAT-APG------L" & ResolutionCode == "PT60M",]
+
+d.agg = d.base.f[, .(mean = mean(Price),
+                                    max = max(Price),
+                                    min = min(Price)), by = .(date = as.Date(DateTime))][order(date)]
+
+d.base.f.hourly = d.base[ResolutionCode == "PT60M",
                   hour := floor_date(DateTime, unit = "hours")]
 
-d.agg = d.base.f[MapCode == "AT", .(mean = mean(Price),
-                                    max = max(Price),
-                                    min = min(Price)), by = .(date = as.Date(DateTime))]
-
-d.agg.hours = d.base.f[, .(price = mean(Price)), by = .(country = MapCode,
+d.agg.hours = d.base.f.hourly[, .(price = mean(Price)), by = .(country = MapCode,
                                                         DateTime = hour,
-                                                        ResolutionCode)]
+                                                        ResolutionCode)][order(country, DateTime)]
 
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 1)
@@ -48,3 +50,4 @@ saveToStorages(
         update.time = update.time
     )
 )
+

--- a/load/entsoe/price.r
+++ b/load/entsoe/price.r
@@ -36,7 +36,8 @@ d.agg.hours = d.base.f[, .(
     min = min(Price)
 ), by = .(
     AreaName,
-    DateTime = ymd_hms(hour)
+    DateTime = ymd_hms(hour),
+    ResolutionCode
 )]
 
 # sort(unique(d.base.f$ResolutionCode))

--- a/load/entsoe/price.r
+++ b/load/entsoe/price.r
@@ -7,14 +7,19 @@ source("load/entsoe/_shared.r")
 # - DOIT -----------------------------------------------------------------------
 update.time = now()
 d.base = loadEntsoeComb(
-    type = "dayAheadPrices", month.start = month.start, month.end = month.end #, check.updates = FALSE
+    #type = "dayAheadPrices", month.start = month.start, month.end = month.end
+    type = "dayAheadPrices", month.start = month.start, month.end = month.end
+
     # type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE
 )
 
 # unique(d.base[, .(ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
 # d.t = unique(d.base[AreaTypeCode == "CTY", .(ResolutionCode, AreaCode, AreaName, MapCode)])
 
-d.base.f = d.base[AreaCode == "10YAT-APG------L" & ResolutionCode == "PT60M"]
+#d.base.f = d.base[AreaCode == "10YAT-APG------L" & ResolutionCode == "PT60M"]
+d.base.f = d.base[,
+                  hour := cut(DateTime, breaks = "hour")]
+
 # unique(d.base.f[, .(ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
 
 d.agg = d.base.f[, .(
@@ -23,6 +28,15 @@ d.agg = d.base.f[, .(
     min = min(Price)
 ), by = .(
     date = as.Date(DateTime)
+)]
+
+d.agg.hours = d.base.f[, .(
+    mean = mean(Price),
+    max = max(Price),
+    min = min(Price)
+), by = .(
+    AreaName,
+    DateTime = ymd_hms(hour)
 )]
 
 # sort(unique(d.base.f$ResolutionCode))
@@ -42,6 +56,13 @@ d.agg = removeLastDays(d.agg, 1)
 # # - STORE --------------------------------------------------------------------
 saveToStorages(d.agg, list(
     id = "electricity-price-entsoe",
+    source = "entsoe",
+    format = "csv",
+    update.time = update.time
+))
+
+saveToStorages(d.agg.hours, list(
+    id = "electricity-price-entsoe-hourly",
     source = "entsoe",
     format = "csv",
     update.time = update.time

--- a/load/entsoe/price.r
+++ b/load/entsoe/price.r
@@ -6,48 +6,43 @@ source("load/entsoe/_shared.r")
 
 # - DOIT -----------------------------------------------------------------------
 update.time = now()
-d.base = loadEntsoeComb(#type = "dayAheadPrices", month.start = month.start, month.end = month.end
-    type = "dayAheadPrices",
-    month.start = month.start,
-    month.end = month.end)
+d.base = loadEntsoeComb(
+    type = "dayAheadPrices", month.start = month.start, month.end = month.end #, check.updates = FALSE
+    # type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE
+)
 
-# type = "load", month.start = "2019-12", month.end = month.end, check.updates = TRUE)
+# unique(d.base[, .(ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
+# d.t = unique(d.base[AreaTypeCode == "CTY", .(ResolutionCode, AreaCode, AreaName, MapCode)])
 
-d.base.f = d.base[AreaCode == "10YAT-APG------L" & ResolutionCode == "PT60M",]
+d.base.f = d.base[AreaCode == "10YAT-APG------L" & ResolutionCode == "PT60M"]
+# unique(d.base.f[, .(ResolutionCode, AreaCode, AreaTypeCode, AreaName, MapCode)])
 
-d.agg = d.base.f[, .(mean = mean(Price),
-                                    max = max(Price),
-                                    min = min(Price)), by = .(date = as.Date(DateTime))][order(date)]
+d.agg = d.base.f[, .(
+    mean = mean(Price),
+    max = max(Price),
+    min = min(Price)
+), by = .(
+    date = as.Date(DateTime)
+)]
 
-d.base.f.hourly = d.base[ResolutionCode == "PT60M",
-                  hour := floor_date(DateTime, unit = "hours")]
+# sort(unique(d.base.f$ResolutionCode))
 
-d.agg.hours = d.base.f.hourly[, .(price = mean(Price)), by = .(country = MapCode,
-                                                        DateTime = hour,
-                                                        ResolutionCode)][order(country, DateTime)]
+# d.base.f[, factor := resToFactor[ResolutionCode]]
+# d.base.f[, value := factor*TotalLoadValue]
+
+# # Filter, Aggregate
+# d.agg = d.base.f[, .(
+#     value = sum(value)/10^3
+# ), by = .(country = MapCode, date = as.Date(DateTime))][order(date)]
 
 # Delete last (most probably incomplete) obs
 d.agg = removeLastDays(d.agg, 1)
 
 
 # # - STORE --------------------------------------------------------------------
-saveToStorages(
-    d.agg,
-    list(
-        id = "electricity-price-entsoe",
-        source = "entsoe",
-        format = "csv",
-        update.time = update.time
-    )
-)
-
-saveToStorages(
-    d.agg.hours,
-    list(
-        id = "electricity-price-entsoe-hourly",
-        source = "entsoe",
-        format = "csv",
-        update.time = update.time
-    )
-)
-
+saveToStorages(d.agg, list(
+    id = "electricity-price-entsoe",
+    source = "entsoe",
+    format = "csv",
+    update.time = update.time
+))


### PR DESCRIPTION
Add a new analysis (an rmd file) which assesses the market value of renewables and of storage. For that purpose, hourly data are necessary, and therefore entso-e data at hourly resolution is stored. This required an update of the respective download files.

- price.r: storing price data, some cleaning, some changes to daily data
- load.r: for deriving daily data, first calculate the mean of hourly values, instead of summing up over values as done in the previous version. The advantage: if data points within an hour are lacking, the estimate is improved. Furthermore, hourly load data is stored on disk for all countries.
- generation.r: as in load.r, the mean of hourly values is calculated in this version. Furthermore, hourly load data is stored on disk for all countries.

I used data.table code in the download scripts, but used tidyverse in the scripts dealing with the analysis. 

- I have tested the new daily data against the current version online on google drive. There are of course changes due to the new procedure of determining hourly and daily values. Furthermore, I have downloaded the latest data directly from entso-e. However, with the exception of some deviations in hourly data, the data in the new download scripts is in line with the previous version. Nevertheless, a thorough test of the visualization on the website should probably be performed before putting this version online.