### PR TITLE
text changes to gas storage prediction and fixing gas savings

### DIFF
--- a/analysis/gas-savings.rmd
+++ b/analysis/gas-savings.rmd
@@ -205,5 +205,3 @@ kable(d.comp.f, align = "r", escape = FALSE)
 ```
 
 In der obigen Tabelle sind die absoluten Einsparungen im Vergleich zum Vorjahresmonat und im Vergleich zum Durchschnitt des jeweiligen Monats in den Jahren 2017 - 2021 aufgeführt. Daneben sind die modellbasierten witterungsbereinigten Einsparungen dargestellt - einmal ohne die Stromproduktion zu berücksichtigen (Modellvariante 1) und einmal mit der Stromproduktion (Modellvariante 2). 
-
-#Die EU Komission fordert eine Reduktion des Gasverbrauchs um 15% im Zeitraum August 2022 - März 2023 im Vergleich zum Durchschnitt der Periode 2017 - 2021. Die entsprechenden kumulativen Einsparungen ab August 2022 sind in der Tabelle ebenfalls ersichtlich. Seit August waren die Einsparungen bisher also höher als die EU Vorgabe, jedoch liegen die Einsparungen laut den temperaturkorrigierten Modellergebnissen unter diesen 15%, somit wären in einem durchschnittlich kalten Winter höhere Einsparungsanstrengungen notwendig um diese Zielvorgabe zu erfüllen.

--- a/analysis/gas-savings.rmd
+++ b/analysis/gas-savings.rmd
@@ -23,14 +23,14 @@ loadPackages(knitr)
 
 In Medien, aber auch in offiziellen Quellen, bspw. dem Energiemonitor des BMK [energie.gv.at](https://energie.gv.at) werden oft Zahlen zur Gasverbraucheinsparung genannt, die meist auf einfachen Vergleichen zu Vorjahreswerten beruhen. So liegt im Jahr 2022 bspw. der Verbrauch[↗](/single/gas~consumption-aggm) in Summe um `r round(savings.2022*100, 1)` % unter dem Durchschnitt der Jahre `r min(d.base$year)` - 2021, der Gasverbrauch war damit sogar niedriger als im Lockdown-Jahr 2020.
 
-Bei diesen Einschätzungen wird aber der wesentliche Treiber des Gaskonsums - die Außentemperatur - vernachlässigt. Dies führt zu falschen Einschätzungen der Einsparungen, da das bisherige Jahr 2022 durchwegs andere Temperaturverläufe[↗](/single/others~temperature) als die Vorjahre aufweist. Wir wollen hier mit dieser Analyse einen Versuch starten, Gaskonsumeinsparungen korrigiert um Temperatureffekte einzuschätzen. Für den Konsum in Deutschland wurde dies z.b. bereits vom DIW Berlin[↗](https://openenergytracker.org/de/docs/germany/naturalgas/) gemacht. Für Österreich gibt es keine tagesaktuellen Gasverbrauchsdaten, welche zwischen industriellen und Haushaltskunden unterscheiden, wir können die deutschen Analysen also nicht im vollen Umfang replizieren.
+Bei diesen Einschätzungen wird aber ein wesentlicher Treiber des Gaskonsums - die Außentemperatur - vernachlässigt. Dies führt zu falschen Einschätzungen der Einsparungen, da das laufende Jahr natürlich unterschiedliche Temperaturverläufe[↗](/single/others~temperature) als die Vorjahre aufweist. Hier schätzen wir daher Gaskonsumeinsparungen, korrigiert um Temperatureffekte. Für den Konsum in Deutschland wurde dies z.b. bereits vom DIW Berlin[↗](https://openenergytracker.org/de/docs/germany/naturalgas/) gemacht. Für Österreich gibt es keine tagesaktuellen Gasverbrauchsdaten, welche zwischen industriellen und Haushaltskunden unterscheiden, wir können die deutschen Analysen also nicht im vollen Umfang replizieren.
 
 
 ## Verwendete Daten
 
 Als Datengrundlage verwenden wir öffentlich verfügbare Zeitreihen, die hier auf dieser Website auch als Indikatoren geführt werden (Download und Aufbereitsungscripts sind [hier](https://github.com/energy-monitor/explore) auffindbar). 
 
-Die drei maßgeblichen verwendeten Zeitreihen sind:
+Die drei maßgeblichen verwendeten Datengrundlagen sind:
 
 - Gaskonsum: [AGGM - Austrian Gas Grid Managment AG](https://www.aggm.at/)
 - Temperatur: [ERA5](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels?tab=overview)
@@ -41,8 +41,7 @@ Außerdem verwenden wir Informationen über Ferien, Feiertage, und COVID-Lockdow
 
 ## Analyse
 
-Der Verlauf des täglichen Gaskonsums[↗](/single/gas~consumption-aggm) lässt fast durchwegs beträchtliche Einsparungen seit Mitte Juli vermuten.
-Die Temperatur hat allerdings erwartungsgemäß einen großen Einfluss auf den Gaskonsum, wie die folgende Grafik zeigt:
+Der Verlauf des täglichen Gaskonsums[↗](/single/gas~consumption-aggm) lässt fast durchwegs beträchtliche Einsparungen seit dem Jahr 2021 vermuten. Die Temperatur hat allerdings erwartungsgemäß einen großen Einfluss auf den Gaskonsum, wie die folgende Grafik zeigt:
 
 ```{r consumTemp}
 d.loess = get.d.loess(d.base)
@@ -59,12 +58,12 @@ ggplot(d.loess, aes(x = temp, y = gas.consumption)) +
 
 *Spart Österreich also tatsächlich - oder war es 2022 nur ungewöhnlich warm?*
 
-Unter einem Schwellwert von knapp 15 Grad Celsius wirkt der Zusammenhang sehr linear, darüber ist der Einfluss halbwegs konstant. Deshalb wird im folgenden Modell nicht auf die Temperatur direkt geschätzt. Wir berechnen stattdessen die Differenz zwischen 15 Grad und der gemessenen Temperatur, falls die gemessene Temperatur unter 15°C ist. Ansonsten setzen wir die Variable auf 0. Im Grunde ähnlich dem Konzept der [Heizgradtage](https://de.wikipedia.org/wiki/Gradtagzahl).
+Unter einem Schwellwert von knapp 15 Grad Celsius wirkt der Zusammenhang linear, darüber ist der Einfluss eher konstant. Deshalb wird im folgenden Modell nicht auf die Temperatur direkt geschätzt. Wir berechnen stattdessen die Differenz zwischen 15 Grad und der gemessenen Temperatur, falls die gemessene Temperatur unter 15°C ist. Ansonsten setzen wir die Variable auf 0. Im Grunde ähnelt dies dem Konzept der [Heizgradtage](https://de.wikipedia.org/wiki/Gradtagzahl).
 
 
 ### Modell
 
-Wir verwenden ein einfaches lineares Modell (OLS), um den Einfluss der Temperatur auf den Verbrauch abzuschätzen. Dies ermöglicht uns in Folge eine Prognose der Einsparungen zu berechnen: wir schätzen die Abhängigkeit des Gasverbrauchs von der Temperatur für den Zeitraum vor der Energiekrise (2015-2021) und prognostizieren damit dann den Gaskonsum im Jahr 2022. Diese Prognose vergleichen wir in Folge mit dem tatsächlichen Gaskonsum im Jahr 2022.
+Wir verwenden ein einfaches lineares Modell (OLS), um den Einfluss der Temperatur auf den Verbrauch abzuschätzen. Dies ermöglicht uns in Folge eine Prognose der Einsparungen zu berechnen: wir schätzen die Abhängigkeit des Gasverbrauchs von der Temperatur für den Zeitraum vor der Energiekrise (2015-2021) und prognostizieren damit dann den Gaskonsum in den Folgejahren. Diese Prognose vergleichen wir in Folge mit dem tatsächlichen Gaskonsum.
 
 Da wir tägliche Daten verwenden, haben wir auch Tagesspezifika in die Regression eingefügt, welche auch Auswirkungen auf den tagespezifischen Gaskonsum haben (bspw. Wochentag, Feiertag, Covid19-Lockdowns, ...). Diese verwendeten Datenreihen sind allesamt täglich seit 2015 verfügbar, wir haben daher `r nrow(d.base)` Beobachtungen.
 
@@ -112,7 +111,7 @@ c.nice.names = c(
 getSummaryTable(l.model.base$m, c.nice.names)
 ```
 
-Mit diesem Modell wird nun der Gaskonsum für die einzelnen Tage im Jahr 2022 geschätzt. Der Unterschied der in 2022 beobachteten Werte von unserer Prognose kann als temperaturunabhängige Konsumänderung interpretiert werden. Von Juni bis Mitte Oktober war der beobachtete Wert fast immer unter unserer Schätzung, wir gehen daher für diesen Zeitraum von Einsparungen, die über die klimatischen Bedingungen hinausgehen, aus.
+Mit diesem Modell wird nun der Gaskonsum für die einzelnen Tage in den Jahren nach 2021 geschätzt. Dabei halten wir den Zeittrend konstant - wir gehen also davon aus, dass im hypothetischen Vergleichsszenario alle von uns nicht berücksichtigten Einflussfaktoren (wie z.b. Politik), jenen im Jahr 2021 entsprechen. Der Unterschied der beobachteten Werte von unserer Prognose kann als temperaturunabhängige Konsumänderung interpretiert werden (gezeigt werden die Werte des aktuellen Jahres). Meist war der beobachtete Wert unter unserer Schätzung, wir gehen daher für von Einsparungen, die über die klimatischen Bedingungen hinausgehen, aus.
 
 ```{r modelResultLevelsBase}
 d.plot = rbind(
@@ -138,10 +137,10 @@ ggplot(d.plot, aes(x = date, y = rollmean, color = variable, group = variable)) 
 
 ```
 
-Noch deutlicher kann dies gezeigt werden, imdem wir die relativen Abweichungen der beiden Kurven plotten. Hier zeigt sich allerdings deutlich, dass ab Mitte Oktober die Einsparungen stark zurückgehen - das passt zu den seit Anfang September stark gefallenen Gaspreisen[↗](/single/gas~price).
+Noch deutlicher kann dies gezeigt werden, in dem wir die relativen Abweichungen der beiden Kurven plotten, wieder für das aktuelle Jahr. 
 
 ```{r modelResultDiffBase}
-dcast(l.model.base$d.plot[date >= "2022-03-01"], date ~ variable, value.var = "rollmean") %>%
+dcast(l.model.base$d.plot[date >= glue("{current_year}-01-01")], date ~ variable, value.var = "rollmean") %>%
     ggplot(aes(x = date, y = difference * 100)) +
         geom_line(linewidth = 1) +
         geom_abline(slope = 0, intercept = 0, linewidth = 0.5, linetype = 2) +
@@ -161,7 +160,7 @@ Allerdings berücksichtigen wir in dieser Analyse nicht, dass der Gasverbrauch a
 
 ## Alternative Variante
 
-Obwohl der Stromverbrauch in Österreich zuletzt leicht gesunken ist [↗](/single/electricity~load), ist die Stromproduktion aus Gaskraftwerken höher als in den 3 Jahren zuvor [↗](/single/electricity~generation-gas). Dies hat damit zu tun, dass die Wasserkraftproduktion in Österreich dieses Jahr - vor allem im Sommer - unter der Produktion der vergangenen Jahren lag [↗](/single/electricity~generation-g1). Wir fügen daher dem Modell als erklärende Variable auch den Gasverbrauch zur Stromproduktion hinzu. In der Prognose sehen wir damit nur mehr die Einsparungen im Industrie- und Haushaltssektor, ohne der Verwendung von Gas für die Stromproduktion. Hier sind die Einsparungen deutlich höher.  
+Wir fügen daher dem Modell als erklärende Variable auch den Gasverbrauch zur Stromproduktion hinzu. In der Prognose sehen wir damit nur mehr die Einsparungen im Industrie- und Haushaltssektor, ohne der Verwendung von Gas für die Stromproduktion. 
 
 ```{r regressionResultPower, include=FALSE}
 getSummaryTable(l.model.power$m, c.nice.names)
@@ -169,7 +168,7 @@ getSummaryTable(l.model.power$m, c.nice.names)
 
 
 ```{r modelResultDiffPower}
-dcast(l.model.power$d.plot[date >= "2022-03-01"], date ~ variable, value.var = "rollmean") %>%
+dcast(l.model.power$d.plot[date >= glue("{current_year}-01-01")], date ~ variable, value.var = "rollmean") %>%
     ggplot(aes(x = date, y = difference * 100)) +
         geom_line(linewidth = 1) +
         geom_abline(slope = 0, intercept = 0, linewidth = 0.5, linetype = 2) +
@@ -207,4 +206,4 @@ kable(d.comp.f, align = "r", escape = FALSE)
 
 In der obigen Tabelle sind die absoluten Einsparungen im Vergleich zum Vorjahresmonat und im Vergleich zum Durchschnitt des jeweiligen Monats in den Jahren 2017 - 2021 aufgeführt. Daneben sind die modellbasierten witterungsbereinigten Einsparungen dargestellt - einmal ohne die Stromproduktion zu berücksichtigen (Modellvariante 1) und einmal mit der Stromproduktion (Modellvariante 2). 
 
-Die EU Komission fordert eine Reduktion des Gasverbrauchs um 15% im Zeitraum August 2022 - März 2023 im Vergleich zum Durchschnitt der Periode 2017 - 2021. Die entsprechenden kumulativen Einsparungen ab August 2022 sind in der Tabelle ebenfalls ersichtlich. Seit August waren die Einsparungen bisher also höher als die EU Vorgabe, jedoch liegen die Einsparungen laut den temperaturkorrigierten Modellergebnissen unter diesen 15%, somit wären in einem durchschnittlich kalten Winter höhere Einsparungsanstrengungen notwendig um diese Zielvorgabe zu erfüllen.
+#Die EU Komission fordert eine Reduktion des Gasverbrauchs um 15% im Zeitraum August 2022 - März 2023 im Vergleich zum Durchschnitt der Periode 2017 - 2021. Die entsprechenden kumulativen Einsparungen ab August 2022 sind in der Tabelle ebenfalls ersichtlich. Seit August waren die Einsparungen bisher also höher als die EU Vorgabe, jedoch liegen die Einsparungen laut den temperaturkorrigierten Modellergebnissen unter diesen 15%, somit wären in einem durchschnittlich kalten Winter höhere Einsparungsanstrengungen notwendig um diese Zielvorgabe zu erfüllen.

--- a/analysis/gas-storage.rmd
+++ b/analysis/gas-storage.rmd
@@ -4,6 +4,7 @@ output: md_document
 date: '2022-11-20'
 ---
 
+
 ```{r setupBase, include=FALSE}
 # - INIT -----------------------------------------------------------------------
 source("calc/setup-storage-prediction.r")
@@ -18,9 +19,9 @@ loadPackages(knitr)
     Code: <a href="https://github.com/energy-monitor/explore/blob/main/analysis/gas-storage.rmd" target="_blank">↗</a>
 </p>
 
-Laut [energie.gv.at](https://energie.gv.at) lagen am `r l.gas.info$l.storage$d.domestic.official.last$date` rund `r round(l.gas.info$l.storage$d.domestic.official.last$level, 1)` TWh Gas in österreichischen Speichern das für österreichische Energiekonsument*innen bestimmt war. Dazu kommt die von der Bundesregierung betriebene strategische Gasreserve von 20 TWh. 2022 ist die österreichische Bundesregierung von einer österreichischen Gaseigenproduktion von 4 TWh im Winter ausgegangen - und mit Winterimporten von 33 TWh. Falls Russland die Exporte stoppt, würden Winterimporte von 23 TWh in dieser Periode erwartet werden. Wir setzen die gleichen Annahmen für den Winter 2023/2024 an.
+Laut [energie.gv.at](https://energie.gv.at) lagen am `r l.gas.info$l.storage$d.domestic.official.last$date` rund `r round(l.gas.info$l.storage$d.domestic.official.last$level, 1)` TWh Gas in österreichischen Speichern das für österreichische Energiekonsument*innen bestimmt war. Dazu kommt die von der Bundesregierung betriebene strategische Gasreserve von 20 TWh. 2022 ist die österreichische Bundesregierung von einer österreichischen Gaseigenproduktion von 4 TWh im Winter ausgegangen - und mit Winterimporten von 33 TWh. Falls Russland die Exporte stoppt, würden Winterimporte von 23 TWh in dieser Periode erwartet werden. Wir setzen die gleichen Annahmen für die Folgewinter an.
 
-In der untenstehenden Grafik trainieren wir zuerst ein Modell, um den Gasverbrauch abhängig von der Außentemperatur abschätzen zu können. Und zwar trainieren wir es auf Daten für die 365 zurückliegenden Tage, um die aktuellen Verhaltensänderungen miteinzubeziehen. Dieses Modell verwenden wir in Folge, um bis Ende März den Verbrauch zu schätzen - und zwar für alle Außentemperaturen, die in diesem Zeitraum in den Jahren 1950 - 2021 geherrscht haben. Wir bekommen damit also 72 Verbrauchsszenarien. Aus diesen - und aus den Annahmen über zukünftige Gaslieferungen und die zukünftige Gasproduktion im Inland - können wir dann Szenarien über den Gasspeicherstand im Winter 23/24 berechnen. Wieviel Gas in österreichischen Gasspeichern tatsächlich für österreichische Kund/innen reserviert ist, wird nur wöchentlich publiziert. Täglich publiziert wird aber der Gesamtspeicherstand in österreichischen Speichern. Wir nehmen daher an, dass sich der Gesamtspeicherstand und der Speicherstand des für Österreich bestimmten Gases proportional ändern. 
+In der untenstehenden Grafik trainieren wir zuerst ein Modell, um den Gasverbrauch abhängig von der Außentemperatur abschätzen zu können. Und zwar trainieren wir es auf Daten für die 365 zurückliegenden Tage, um die aktuellen Verhaltensänderungen miteinzubeziehen. Dieses Modell verwenden wir in Folge, um bis Ende März den Verbrauch zu schätzen - und zwar für alle Außentemperaturen, die in diesem Zeitraum in den Jahren 1950 - 2021 geherrscht haben. Wir bekommen damit also 72 Verbrauchsszenarien. Aus diesen - und aus den Annahmen über zukünftige Gaslieferungen und die zukünftige Gasproduktion im Inland - können wir dann Szenarien über den Gasspeicherstand im aktuellen Winter berechnen. Wieviel Gas in österreichischen Gasspeichern tatsächlich für österreichische Kund/innen reserviert ist, wird nur wöchentlich publiziert. Täglich publiziert wird aber der Gesamtspeicherstand in österreichischen Speichern. Wir nehmen daher an, dass sich der Gesamtspeicherstand und der Speicherstand des für Österreich bestimmten Gases proportional ändern. 
 
 ```{r plot, fig.height=6}
 d.t.storage = d.base[date >= l.options$period$start & !is.na(storage.dom), .(
@@ -51,7 +52,7 @@ annotation <- tibble(
     label = c(
         "Strategische Gasreserve"
     ),
-    x = c(as.Date("2023-11-01")),
+    x = c(as.Date("2024-02-01")),
     y = c(19)
 )
 
@@ -72,7 +73,7 @@ ggplot(d.t.pred, aes(x = date, y = value)) +
     ) +
     labs(
         title = "Entwicklung Speicherstand",
-        subtitle = "Heizsaison 23/24, Speicherniveau in TWh"
+        subtitle = "Speicherniveau in TWh"
     )
 ```
 

--- a/calc/prediction-gas-consumption/_shared.r
+++ b/calc/prediction-gas-consumption/_shared.r
@@ -35,16 +35,34 @@ d.comb = copy(d.base)
 addTempThreshold(d.comb, temp.threshold)
 addTrend(d.comb)
 
+t_max = d.comb %>%
+    filter(year == 2021) %>%
+    filter(t == max(t)) %>%
+    dplyr::select(t) %>%
+    unlist()
+
+d.comb <- d.comb %>%
+    mutate(t = ifelse(year(date) > 2021, t_max, t))
+
+d.comb <- d.comb %>%
+    mutate(t.squared = ifelse(year(date) > 2021, t_max^2, t))
+
+
 # MODEL DEFINITION
 model.base = gas.consumption ~
-    t + t.squared + # week +
+    t +
+    t.squared + # week +
     temp.below.threshold + temp.below.threshold.lag + temp.below.threshold.squared +
     wday + is.holiday + as.factor(vacation.name) + is.lockdown + is.hard.lockdown
+
+
 
 l.model.base = estimate(model.base, d.comb)
 
 model.power = gas.consumption ~
-    t + t.squared + gas.power + # week +
+    t +
+    t.squared +
+    gas.power + # week +
     temp.below.threshold + temp.below.threshold.lag + temp.below.threshold.squared +
     wday + is.holiday + as.factor(vacation.name) + is.lockdown + is.hard.lockdown
 

--- a/calc/setup-storage-prediction.r
+++ b/calc/setup-storage-prediction.r
@@ -10,7 +10,7 @@ l.options = list(
     lag.max = 1,
     period = list(
         start = as.Date("2023-09-01"),
-        end = as.Date("2024-06-01"),
+        end = as.Date("2024-09-01"),
         pred.start = as.Date("2023-09-01")
     ),
     learning.days = 365
@@ -47,6 +47,7 @@ l.gas.info = list(
             "2023-09-01" = 23.47 + 4.94,
             "2023-09-26" = 23.47 + 4.94,
             "2023-10-03" = 23.74 + 4.94
+#            "2024-07-29" = 20.40 + 5.47
 
         )
 


### PR DESCRIPTION
I improved some of the text for the gas storage prediction and the gas savings pages.
Furthermore, I fixed the timetrend at the end of 2021 for predicing gas consumption afterwards. This is a different counter-factual from before, but I think it better represents our claim that we correct for temperature only...