### PR TITLE
Fix visulization of generation data

### DIFF
--- a/load/entsoe/_shared.r
+++ b/load/entsoe/_shared.r
@@ -28,7 +28,7 @@ c.resToFactor = c(
 )
 
 c.sourceGroups1 = list(
-    "Hydro"   = c("Hydro Run-of-river and poundage", "Hydro Water Reservoir", "Hydro Pumped Storage"),
+    "Hydro"   = c("Hydro Run-of-river and pondage", "Hydro Water Reservoir", "Hydro Pumped Storage"),
     "Wind"    = c("Wind Onshore", "Wind Offshore"),
     "Gas"     = c("Fossil Gas"),
     "Solar"   = c("Solar"),


### PR DESCRIPTION
entso-e changed the naming of "Hydro Run-of-river and poundage" to "Hydro Run-of-river and pondage", therefore run-of-river hydropower was visualized in category "other" on the webpage. The code was therefore adapted accordingly.