### PR TITLE
Fix naming of columns

### DIFF
--- a/load/entsoe/load-hourly-res.r
+++ b/load/entsoe/load-hourly-res.r
@@ -10,12 +10,13 @@ d.base = load_entsoe(
     c.nice2entsoe["load"], from = date.start
 )
 
-d.base.f = d.base[AreaTypeCode == "CTY"]
+d.base.f = d.base[AreaTypeCode == "CTY",]
+setnames(d.base.f, "DateTime(UTC)", "DateTime")
 d.base.f[, hour := (floor_date(DateTime, unit = "hours"))]
 
 d.agg = d.base.f[, .(
-    value = mean(TotalLoadValue, na.rm = TRUE)
-), by = .(country = MapCode, DateTime = hour)]
+    value = mean(`TotalLoad[MW]`, na.rm = TRUE)
+), by = .(country = AreaMapCode, DateTime = hour)]
 
 
 # - STORE ----------------------------------------------------------------------


### PR DESCRIPTION
Due to new entso-e data format, naming of columns had to be adapted.