### PR TITLE
Changes to account for changes in entso-e format

### DIFF
--- a/load/entsoe/load-hourly-res.r
+++ b/load/entsoe/load-hourly-res.r
@@ -10,7 +10,7 @@ d.base = load_entsoe(
     c.nice2entsoe["load"], from = date.start
 )
 
-d.base.f = d.base[AreaTypeCode == "CTY",]
+d.base.f = d.base[AreaTypeCode == "CTY"|AreaTypeCode == "BZN/CTA/CTY",]
 setnames(d.base.f, "DateTime(UTC)", "DateTime")
 d.base.f[, hour := (floor_date(DateTime, unit = "hours"))]
 

--- a/load/entsoe/price-hourly-res.r
+++ b/load/entsoe/price-hourly-res.r
@@ -11,7 +11,7 @@ d.base = load_entsoe(
 )
 setnames(d.base, "DateTime(UTC)", "DateTime")
 
-d.base.f = d.base[ResolutionCode == "PT60M"]
+d.base.f = d.base[ResolutionCode == "PT60M"| ResolutionCode == "PT15M",]
 d.base.f = d.base.f[, hour := floor_date(DateTime, unit = "hours")]
 
 d.agg = d.base.f[, .(


### PR DESCRIPTION
Entso-e format for AT and other regions has changed, therefore modifications to the download of load and price where necessary. In particular, the ResolutionCode for Austria and other regions has changed from 60M to 15M and the areacode for austria has changed from CTY to BZN/CTA/CTY.